### PR TITLE
自動計画ボタンとタスク自動配分機能を追加

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 import ProjectSettingsForm from '~/components/ProjectSettingsForm';
 import CategoryManager from '~/components/CategoryManager';
+import AutoPlanButton from '~/components/AutoPlanButton';
 import type { FC } from 'react';
 
 const App: FC = () => {
@@ -12,6 +13,7 @@ const App: FC = () => {
       <main className="mx-auto mt-8 max-w-5xl">
         <ProjectSettingsForm />
         <CategoryManager />
+        <AutoPlanButton />
       </main>
     </div>
   );

--- a/src/components/AutoPlanButton.test.tsx
+++ b/src/components/AutoPlanButton.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AutoPlanButton from './AutoPlanButton';
+
+const CAT_KEY = 'goal-steps:categories';
+const PROJ_KEY = 'goal-steps:project-settings';
+const TASK_KEY = 'goal-steps:tasks';
+
+describe('AutoPlanButton', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('generates tasks into localStorage when clicked', () => {
+    localStorage.setItem(PROJ_KEY, JSON.stringify({ name: 'P', deadline: '2025-12-31' }));
+    localStorage.setItem(
+      CAT_KEY,
+      JSON.stringify([
+        {
+          id: 'c1',
+          name: '国語',
+          minAmount: 20,
+          maxAmount: 20,
+          minUnit: 2,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]),
+    );
+
+    render(<AutoPlanButton />);
+    fireEvent.click(screen.getByRole('button', { name: '自動計画を作成' }));
+    const stored = JSON.parse(localStorage.getItem(TASK_KEY) || '[]');
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored.length).toBeGreaterThan(0);
+    expect(screen.getByText(/タスクを\d+件作成しました/)).toBeInTheDocument();
+  });
+});

--- a/src/components/AutoPlanButton.tsx
+++ b/src/components/AutoPlanButton.tsx
@@ -1,0 +1,29 @@
+import { useState, type FC } from 'react';
+import autoAllocateTasks from '~/lib/autoAllocate';
+
+const AutoPlanButton: FC = () => {
+  const [message, setMessage] = useState('');
+
+  const handleClick = () => {
+    const tasks = autoAllocateTasks();
+    setMessage(
+      tasks.length > 0 ? `タスクを${tasks.length}件作成しました` : 'タスクを作成できませんでした',
+    );
+  };
+
+  return (
+    <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="自動計画">
+      <h2 className="text-lg font-semibold mb-4">自動計画</h2>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="rounded bg-green-600 px-3 py-1.5 text-white hover:bg-green-700"
+      >
+        自動計画を作成
+      </button>
+      {message && <p className="mt-2 text-sm">{message}</p>}
+    </section>
+  );
+};
+
+export default AutoPlanButton;

--- a/src/lib/autoAllocate.ts
+++ b/src/lib/autoAllocate.ts
@@ -1,0 +1,93 @@
+import type { Category, TaskBlock } from '~/types';
+
+const CAT_KEY = 'goal-steps:categories';
+const PROJ_KEY = 'goal-steps:project-settings';
+const TASK_KEY = 'goal-steps:tasks';
+const WEEK_KEY = 'goal-steps:weekday-settings';
+
+const uid = () => Math.random().toString(36).slice(2, 10);
+
+const weightMap: Record<string, number> = {
+  more: 1.5,
+  normal: 1,
+  less: 0.5,
+  none: 0,
+};
+
+const defaultWeek: Record<number, number> = {
+  0: 1,
+  1: 1,
+  2: 1,
+  3: 1,
+  4: 1,
+  5: 1,
+  6: 1,
+};
+
+function loadWeekWeights(): Record<number, number> {
+  const raw = localStorage.getItem(WEEK_KEY);
+  if (!raw) return defaultWeek;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, keyof typeof weightMap>;
+    const weights: Record<number, number> = { ...defaultWeek };
+    for (let i = 0; i < 7; i++) {
+      const key = String(i);
+      if (parsed[key] && weightMap[parsed[key]]) {
+        weights[i] = weightMap[parsed[key]];
+      }
+    }
+    return weights;
+  } catch {
+    return defaultWeek;
+  }
+}
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function autoAllocateTasks(today = new Date()): TaskBlock[] {
+  const categories = JSON.parse(localStorage.getItem(CAT_KEY) || '[]') as Category[];
+  const project = JSON.parse(localStorage.getItem(PROJ_KEY) || '{}') as { deadline?: string };
+  if (!project.deadline) return [];
+  const weekWeights = loadWeekWeights();
+  const tasks: TaskBlock[] = [];
+  const start = new Date(formatDate(today));
+
+  for (const c of categories) {
+    const deadline = c.deadline && c.deadline < project.deadline ? c.deadline : project.deadline;
+    const end = new Date(deadline);
+    const days: string[] = [];
+    const d = new Date(start);
+    while (d <= end) {
+      const w = weekWeights[d.getDay()];
+      if (w > 0) days.push(formatDate(d));
+      d.setDate(d.getDate() + 1);
+    }
+    if (days.length === 0) continue;
+
+    const weightedDays: string[] = [];
+    for (const day of days) {
+      const dow = new Date(day).getDay();
+      const w = weekWeights[dow];
+      const mult = w === 1.5 ? 3 : w === 1 ? 2 : w === 0.5 ? 1 : 0;
+      for (let i = 0; i < mult; i++) weightedDays.push(day);
+    }
+    const total = c.maxAmount;
+    const unit = c.minUnit;
+    let remaining = total;
+    let i = 0;
+    while (remaining > 0) {
+      const amount = remaining >= unit ? unit : remaining;
+      const date = weightedDays[i % weightedDays.length];
+      tasks.push({ id: uid(), categoryId: c.id, amount, date, completed: false });
+      remaining -= amount;
+      i++;
+    }
+  }
+
+  localStorage.setItem(TASK_KEY, JSON.stringify(tasks));
+  return tasks;
+}
+
+export default autoAllocateTasks;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,10 @@ export interface Category {
   updatedAt: string; // ISO8601
 }
 
+export interface TaskBlock {
+  id: ID;
+  categoryId: ID;
+  amount: number;
+  date: string; // YYYY-MM-DD
+  completed: boolean;
+}


### PR DESCRIPTION
## 概要
- タスク自動配分アルゴリズムを実装し、ローカルストレージに保存
- 自動計画を起動するトリガーボタンを追加
- アプリに自動計画機能を組み込み

## テスト
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c9fcaf74832d9533bd49b4e8099b