### PR TITLE
feat: deploy to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,18 +31,11 @@ jobs:
       - name: Build
         run: npm run build -- --base=/${{ github.event.repository.name }}/
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
-        with:
-          path: dist
-
-  deploy:
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
       - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8
+        with:
+          branch: gh-pages
+          folder: dist
+          clean: true
+          clean-exclude: |
+            pr-preview/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -- --base=/${{ github.event.repository.name }}/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}
@@ -27,3 +28,4 @@ jobs:
         uses: rossjrw/pr-preview-action@9f77b1d057b494e662c50b8ca40ecc63f21e0887
         with:
           source-dir: ./dist
+          comment: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,52 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -- --base=/${{ github.event.repository.name }}/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        with:
+          preview: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,38 +15,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build -- --base=/${{ github.event.repository.name }}/
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
-        with:
-          path: dist
-
   deploy:
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - name: Deploy PR Preview
+        uses: github/deploy-pr-preview@f8c5befb50daca49b9a5a5bab405fc52d38158c9
         with:
-          preview: true
+          build_script: |
+            npm ci
+            npm run build -- --base=/${{ github.event.repository.name }}/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,12 +3,11 @@ name: Deploy PR Preview
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}
@@ -19,9 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Deploy PR Preview
-        uses: github/deploy-pr-preview@f8c5befb50daca49b9a5a5bab405fc52d38158c9
+      - name: Install dependencies and build
+        if: github.event.action != 'closed'
+        run: |
+          npm ci
+          npm run build -- --base=/${{ github.event.repository.name }}/
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@9f77b1d057b494e662c50b8ca40ecc63f21e0887
         with:
-          build_script: |
-            npm ci
-            npm run build -- --base=/${{ github.event.repository.name }}/
+          source-dir: ./dist

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -23,7 +23,7 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           npm ci
-          npm run build -- --base=/${{ github.event.repository.name }}/
+          npm run build -- --base=/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@9f77b1d057b494e662c50b8ca40ecc63f21e0887
         with:

--- a/README.md
+++ b/README.md
@@ -160,3 +160,8 @@ npm run build
 # ビルド結果プレビュー
 npm run preview
 ```
+
+### GitHub Pages
+
+mainブランチにマージされると GitHub Actions が自動でビルドを行い、生成された `dist` ディレクトリが GitHub Pages にデプロイされます。公開されたサイトは Actions の実行結果から確認できます。また、Pull Request ごとに [Deploy PR Preview](https://github.com/github/deploy-pr-preview) によるプレビューが生成され、PR のチェックから確認可能です。
+

--- a/README.md
+++ b/README.md
@@ -163,5 +163,5 @@ npm run preview
 
 ### GitHub Pages
 
-mainブランチにマージされると GitHub Actions が自動でビルドを行い、生成された `dist` ディレクトリが GitHub Pages にデプロイされます。公開されたサイトは Actions の実行結果から確認できます。また、Pull Request ごとに [Deploy PR Preview](https://github.com/github/deploy-pr-preview) によるプレビューが生成され、PR のチェックから確認可能です。
+mainブランチにマージされると GitHub Actions が自動でビルドを行い、生成された `dist` ディレクトリが GitHub Pages にデプロイされます。公開されたサイトは Actions の実行結果から確認できます。また、Pull Request ごとに [Deploy PR Preview](https://github.com/marketplace/actions/deploy-pr-preview) によるプレビューが生成され、PR のチェックから確認可能です。
 

--- a/README.md
+++ b/README.md
@@ -163,5 +163,5 @@ npm run preview
 
 ### GitHub Pages
 
-mainブランチにマージされると GitHub Actions が自動でビルドを行い、生成された `dist` ディレクトリが GitHub Pages にデプロイされます。公開されたサイトは Actions の実行結果から確認できます。また、Pull Request ごとに [Deploy PR Preview](https://github.com/marketplace/actions/deploy-pr-preview) によるプレビューが生成され、PR のチェックから確認可能です。
+mainブランチにマージされると GitHub Actions が自動でビルドを行い、生成された `dist` ディレクトリが GitHub Pages にデプロイされます。公開されたサイトは Actions の実行結果から確認できます。また、Pull Request ごとに [Deploy PR Preview](https://github.com/marketplace/actions/deploy-pr-preview) によるプレビューが生成され、PR のチェックやコメントから確認可能です。
 


### PR DESCRIPTION
## Summary
- build and deploy to GitHub Pages on merge to main
- deploy PR previews with Deploy PR Preview
- document Pages deployment workflow
- pin GitHub Action versions to specific commit hashes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c99169f8832d8304535b1276cc81