### PR TITLE
feat: add calendar task view

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import ProjectSettingsForm from '~/components/ProjectSettingsForm';
 import CategoryManager from '~/components/CategoryManager';
 import AutoPlanButton from '~/components/AutoPlanButton';
+import CalendarView from '~/components/CalendarView';
 import type { FC } from 'react';
 
 const App: FC = () => {
@@ -14,6 +15,7 @@ const App: FC = () => {
         <ProjectSettingsForm />
         <CategoryManager />
         <AutoPlanButton />
+        <CalendarView />
       </main>
     </div>
   );

--- a/src/components/AutoPlanButton.test.tsx
+++ b/src/components/AutoPlanButton.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, expect } from 'vitest';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AutoPlanButton from './AutoPlanButton';
@@ -30,10 +30,13 @@ describe('AutoPlanButton', () => {
     );
 
     render(<AutoPlanButton />);
+    const listener = vi.fn();
+    window.addEventListener('tasks:updated', listener);
     fireEvent.click(screen.getByRole('button', { name: '自動計画を作成' }));
     const stored = JSON.parse(localStorage.getItem(TASK_KEY) || '[]');
     expect(Array.isArray(stored)).toBe(true);
     expect(stored.length).toBeGreaterThan(0);
     expect(screen.getByText(/タスクを\d+件作成しました/)).toBeInTheDocument();
+    expect(listener).toHaveBeenCalled();
   });
 });

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CalendarView from './CalendarView';
+
+describe('CalendarView', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('displays tasks from localStorage on corresponding dates', () => {
+    localStorage.setItem(
+      'goal-steps:categories',
+      JSON.stringify([
+        {
+          id: 'c1',
+          name: 'カテゴリ1',
+          minAmount: 1,
+          maxAmount: 1,
+          minUnit: 1,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]),
+    );
+    localStorage.setItem(
+      'goal-steps:tasks',
+      JSON.stringify([
+        { id: 't1', categoryId: 'c1', amount: 2, date: '2025-01-05', completed: false },
+      ]),
+    );
+
+    render(<CalendarView initialDate={new Date('2025-01-01')} />);
+    const cell = screen.getByLabelText('2025-01-05');
+    expect(within(cell).getByText('カテゴリ1: 2')).toBeInTheDocument();
+  });
+
+  it('updates when tasks:updated event is dispatched', async () => {
+    localStorage.setItem(
+      'goal-steps:categories',
+      JSON.stringify([
+        {
+          id: 'c1',
+          name: 'カテゴリ1',
+          minAmount: 1,
+          maxAmount: 1,
+          minUnit: 1,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]),
+    );
+    render(<CalendarView initialDate={new Date('2025-01-01')} />);
+    localStorage.setItem(
+      'goal-steps:tasks',
+      JSON.stringify([
+        { id: 't2', categoryId: 'c1', amount: 3, date: '2025-01-10', completed: false },
+      ]),
+    );
+    window.dispatchEvent(new Event('tasks:updated'));
+    const cell = screen.getByLabelText('2025-01-10');
+    await waitFor(() => {
+      expect(within(cell).getByText('カテゴリ1: 3')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect, useMemo, type FC } from 'react';
+import type { TaskBlock, Category } from '~/types';
+
+const TASK_KEY = 'goal-steps:tasks';
+const CAT_KEY = 'goal-steps:categories';
+
+const daysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
+const formatDate = (year: number, month: number, day: number) => {
+  const m = String(month + 1).padStart(2, '0');
+  const d = String(day).padStart(2, '0');
+  return `${year}-${m}-${d}`;
+};
+
+interface Props {
+  initialDate?: Date;
+}
+
+const CalendarView: FC<Props> = ({ initialDate }) => {
+  const [current, setCurrent] = useState(() => {
+    const d = initialDate ?? new Date();
+    return new Date(d.getFullYear(), d.getMonth(), 1);
+  });
+  const [tasks, setTasks] = useState<TaskBlock[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+
+  const loadTasks = () => {
+    const raw = localStorage.getItem(TASK_KEY);
+    if (!raw) {
+      setTasks([]);
+      return;
+    }
+    try {
+      setTasks(JSON.parse(raw) as TaskBlock[]);
+    } catch {
+      setTasks([]);
+    }
+  };
+
+  const loadCategories = () => {
+    const raw = localStorage.getItem(CAT_KEY);
+    if (!raw) {
+      setCategories([]);
+      return;
+    }
+    try {
+      setCategories(JSON.parse(raw) as Category[]);
+    } catch {
+      setCategories([]);
+    }
+  };
+
+  useEffect(() => {
+    loadTasks();
+    loadCategories();
+    const handler = () => loadTasks();
+    window.addEventListener('tasks:updated', handler);
+    return () => window.removeEventListener('tasks:updated', handler);
+  }, []);
+
+  const nameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of categories) map.set(c.id, c.name);
+    return map;
+  }, [categories]);
+
+  const year = current.getFullYear();
+  const month = current.getMonth();
+  const days = daysInMonth(year, month);
+
+  const prevMonth = () => setCurrent(new Date(year, month - 1, 1));
+  const nextMonth = () => setCurrent(new Date(year, month + 1, 1));
+  const goToday = () => {
+    const t = new Date();
+    setCurrent(new Date(t.getFullYear(), t.getMonth(), 1));
+  };
+
+  const grouped: Record<string, TaskBlock[]> = {};
+  for (const t of tasks) {
+    if (!grouped[t.date]) grouped[t.date] = [];
+    grouped[t.date].push(t);
+  }
+
+  const cells = [];
+  for (let day = 1; day <= days; day++) {
+    const dateStr = formatDate(year, month, day);
+    const ts = grouped[dateStr] || [];
+    cells.push(
+      <div key={dateStr} role="gridcell" aria-label={dateStr} className="h-24 border p-1 overflow-y-auto bg-white">
+        <div className="text-xs">{day}</div>
+        {ts.map((t) => (
+          <div key={t.id} data-testid="task-block" className="mt-1 rounded bg-blue-100 p-1 text-xs">
+            {nameMap.get(t.categoryId) ?? t.categoryId}: {t.amount}
+          </div>
+        ))}
+      </div>,
+    );
+  }
+
+  return (
+    <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="カレンダービュー">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="font-semibold">
+          {year}年{month + 1}月
+        </div>
+        <div className="space-x-2">
+          <button type="button" onClick={prevMonth} aria-label="前の月" className="px-2 py-1 border rounded">
+            前
+          </button>
+          <button type="button" onClick={goToday} aria-label="今日" className="px-2 py-1 border rounded">
+            今日
+          </button>
+          <button type="button" onClick={nextMonth} aria-label="次の月" className="px-2 py-1 border rounded">
+            次
+          </button>
+        </div>
+      </div>
+      <div role="grid" className="grid grid-cols-7 gap-px bg-gray-300">
+        {cells}
+      </div>
+    </section>
+  );
+};
+
+export default CalendarView;

--- a/src/lib/autoAllocate.ts
+++ b/src/lib/autoAllocate.ts
@@ -87,6 +87,7 @@ export function autoAllocateTasks(today = new Date()): TaskBlock[] {
   }
 
   localStorage.setItem(TASK_KEY, JSON.stringify(tasks));
+  window.dispatchEvent(new Event('tasks:updated'));
   return tasks;
 }
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,8 @@
 import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
 


### PR DESCRIPTION
## Summary
- add event dispatch after task generation to notify calendar
- load tasks in CalendarView on `tasks:updated` to show new tasks
- test calendar updates and ensure tests cleanup after each run
- display category names in calendar cells

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d9d77cd4832d8b66c3f431692d61