### PR TITLE
refactor: manage page state without window events

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,24 +1,8 @@
-import ProjectSettingsForm from '~/components/ProjectSettingsForm';
-import CategoryManager from '~/components/CategoryManager';
-import AutoPlanButton from '~/components/AutoPlanButton';
-import CalendarView from '~/components/CalendarView';
 import type { FC } from 'react';
+import PlannerPage from '~/pages/PlannerPage';
 
 const App: FC = () => {
-  return (
-    <div className="min-h-screen p-6 md:p-10">
-      <header className="mx-auto max-w-5xl">
-        <h1 className="text-2xl md:text-3xl font-bold">goal-steps</h1>
-        <p className="text-sm text-gray-600 mt-1">目標達成のためのタスク管理を補助するアプリ</p>
-      </header>
-      <main className="mx-auto mt-8 max-w-5xl">
-        <ProjectSettingsForm />
-        <CategoryManager />
-        <AutoPlanButton />
-        <CalendarView />
-      </main>
-    </div>
-  );
+  return <PlannerPage />;
 };
 
 export default App;

--- a/src/components/AutoPlanButton.test.tsx
+++ b/src/components/AutoPlanButton.test.tsx
@@ -1,42 +1,14 @@
-import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AutoPlanButton from './AutoPlanButton';
 
-const CAT_KEY = 'goal-steps:categories';
-const PROJ_KEY = 'goal-steps:project-settings';
-const TASK_KEY = 'goal-steps:tasks';
-
 describe('AutoPlanButton', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('generates tasks into localStorage when clicked', () => {
-    localStorage.setItem(PROJ_KEY, JSON.stringify({ name: 'P', deadline: '2025-12-31' }));
-    localStorage.setItem(
-      CAT_KEY,
-      JSON.stringify([
-        {
-          id: 'c1',
-          name: '国語',
-          minAmount: 20,
-          maxAmount: 20,
-          minUnit: 2,
-          createdAt: '',
-          updatedAt: '',
-        },
-      ]),
-    );
-
-    render(<AutoPlanButton />);
-    const listener = vi.fn();
-    window.addEventListener('tasks:updated', listener);
+  it('calls onPlan and shows message', () => {
+    const onPlan = vi.fn().mockReturnValue(3);
+    render(<AutoPlanButton onPlan={onPlan} />);
     fireEvent.click(screen.getByRole('button', { name: '自動計画を作成' }));
-    const stored = JSON.parse(localStorage.getItem(TASK_KEY) || '[]');
-    expect(Array.isArray(stored)).toBe(true);
-    expect(stored.length).toBeGreaterThan(0);
-    expect(screen.getByText(/タスクを\d+件作成しました/)).toBeInTheDocument();
-    expect(listener).toHaveBeenCalled();
+    expect(onPlan).toHaveBeenCalled();
+    expect(screen.getByText('タスクを3件作成しました')).toBeInTheDocument();
   });
 });

--- a/src/components/AutoPlanButton.tsx
+++ b/src/components/AutoPlanButton.tsx
@@ -1,14 +1,15 @@
 import { useState, type FC } from 'react';
-import autoAllocateTasks from '~/lib/autoAllocate';
 
-const AutoPlanButton: FC = () => {
+interface Props {
+  onPlan: () => number;
+}
+
+const AutoPlanButton: FC<Props> = ({ onPlan }) => {
   const [message, setMessage] = useState('');
 
   const handleClick = () => {
-    const tasks = autoAllocateTasks();
-    setMessage(
-      tasks.length > 0 ? `タスクを${tasks.length}件作成しました` : 'タスクを作成できませんでした',
-    );
+    const count = onPlan();
+    setMessage(count > 0 ? `タスクを${count}件作成しました` : 'タスクを作成できませんでした');
   };
 
   return (

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -1,96 +1,98 @@
-import { describe, it, beforeEach, expect } from 'vitest';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CalendarView from './CalendarView';
+import type { Category, TaskBlock } from '~/types';
 
 describe('CalendarView', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('displays tasks from localStorage on corresponding dates', () => {
-    localStorage.setItem(
-      'goal-steps:categories',
-      JSON.stringify([
-        {
-          id: 'c1',
-          name: 'カテゴリ1',
-          minAmount: 1,
-          maxAmount: 1,
-          minUnit: 1,
-          createdAt: '',
-          updatedAt: '',
-        },
-      ]),
+  it('displays tasks on corresponding dates', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const tasks: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 2, date: '2025-01-05', completed: false },
+    ];
+    render(
+      <CalendarView
+        tasks={tasks}
+        categories={categories}
+        initialDate={new Date('2025-01-01')}
+      />,
     );
-    localStorage.setItem(
-      'goal-steps:tasks',
-      JSON.stringify([
-        { id: 't1', categoryId: 'c1', amount: 2, date: '2025-01-05', completed: false },
-      ]),
-    );
-
-    render(<CalendarView initialDate={new Date('2025-01-01')} />);
     const cell = screen.getByLabelText('2025-01-05');
     expect(within(cell).getByText('カテゴリ1: 2')).toBeInTheDocument();
   });
 
-  it('updates when tasks:updated event is dispatched', async () => {
-    localStorage.setItem(
-      'goal-steps:categories',
-      JSON.stringify([
-        {
-          id: 'c1',
-          name: 'カテゴリ1',
-          minAmount: 1,
-          maxAmount: 1,
-          minUnit: 1,
-          createdAt: '',
-          updatedAt: '',
-        },
-      ]),
+  it('updates when tasks prop changes', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const tasks: TaskBlock[] = [];
+    const { rerender } = render(
+      <CalendarView
+        tasks={tasks}
+        categories={categories}
+        initialDate={new Date('2025-01-01')}
+      />,
     );
-    render(<CalendarView initialDate={new Date('2025-01-01')} />);
-    localStorage.setItem(
-      'goal-steps:tasks',
-      JSON.stringify([
-        { id: 't2', categoryId: 'c1', amount: 3, date: '2025-01-10', completed: false },
-      ]),
+    tasks.push({ id: 't2', categoryId: 'c1', amount: 3, date: '2025-01-10', completed: false });
+    rerender(
+      <CalendarView
+        tasks={tasks}
+        categories={categories}
+        initialDate={new Date('2025-01-01')}
+      />,
     );
-    window.dispatchEvent(new Event('tasks:updated'));
     const cell = screen.getByLabelText('2025-01-10');
-    await waitFor(() => {
-      expect(within(cell).getByText('カテゴリ1: 3')).toBeInTheDocument();
-    });
+    expect(within(cell).getByText('カテゴリ1: 3')).toBeInTheDocument();
   });
 
-  it('shows category names when categories are added after mount', async () => {
-    render(<CalendarView initialDate={new Date('2025-01-01')} />);
-    localStorage.setItem(
-      'goal-steps:categories',
-      JSON.stringify([
-        {
-          id: 'c2',
-          name: 'カテゴリ2',
-          minAmount: 1,
-          maxAmount: 1,
-          minUnit: 1,
-          createdAt: '',
-          updatedAt: '',
-        },
-      ]),
+  it('shows category names when categories prop updates', () => {
+    const categories: Category[] = [];
+    const tasks: TaskBlock[] = [
+      { id: 't3', categoryId: 'c2', amount: 4, date: '2025-01-15', completed: false },
+    ];
+    const { rerender } = render(
+      <CalendarView
+        tasks={tasks}
+        categories={categories}
+        initialDate={new Date('2025-01-01')}
+      />,
     );
-    localStorage.setItem(
-      'goal-steps:tasks',
-      JSON.stringify([
-        { id: 't3', categoryId: 'c2', amount: 4, date: '2025-01-15', completed: false },
-      ]),
-    );
-    window.dispatchEvent(new Event('categories:updated'));
-    window.dispatchEvent(new Event('tasks:updated'));
-    const cell = screen.getByLabelText('2025-01-15');
-    await waitFor(() => {
-      expect(within(cell).getByText('カテゴリ2: 4')).toBeInTheDocument();
+    categories.push({
+      id: 'c2',
+      name: 'カテゴリ2',
+      minAmount: 1,
+      maxAmount: 1,
+      minUnit: 1,
+      createdAt: '',
+      updatedAt: '',
     });
+    rerender(
+      <CalendarView
+        tasks={tasks}
+        categories={[...categories]}
+        initialDate={new Date('2025-01-01')}
+      />,
+    );
+    const cell = screen.getByLabelText('2025-01-15');
+    expect(within(cell).getByText('カテゴリ2: 4')).toBeInTheDocument();
   });
 });
+

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,8 +1,5 @@
-import { useState, useEffect, useMemo, type FC } from 'react';
+import { useState, useMemo, type FC } from 'react';
 import type { TaskBlock, Category } from '~/types';
-
-const TASK_KEY = 'goal-steps:tasks';
-const CAT_KEY = 'goal-steps:categories';
 
 const daysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
 const formatDate = (year: number, month: number, day: number) => {
@@ -12,58 +9,16 @@ const formatDate = (year: number, month: number, day: number) => {
 };
 
 interface Props {
+  tasks: TaskBlock[];
+  categories: Category[];
   initialDate?: Date;
 }
 
-const CalendarView: FC<Props> = ({ initialDate }) => {
+const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
   const [current, setCurrent] = useState(() => {
     const d = initialDate ?? new Date();
     return new Date(d.getFullYear(), d.getMonth(), 1);
   });
-  const [tasks, setTasks] = useState<TaskBlock[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-
-  const loadTasks = () => {
-    const raw = localStorage.getItem(TASK_KEY);
-    if (!raw) {
-      setTasks([]);
-      return;
-    }
-    try {
-      setTasks(JSON.parse(raw) as TaskBlock[]);
-    } catch {
-      setTasks([]);
-    }
-  };
-
-  const loadCategories = () => {
-    const raw = localStorage.getItem(CAT_KEY);
-    if (!raw) {
-      setCategories([]);
-      return;
-    }
-    try {
-      setCategories(JSON.parse(raw) as Category[]);
-    } catch {
-      setCategories([]);
-    }
-  };
-
-  useEffect(() => {
-    loadTasks();
-    loadCategories();
-    const taskHandler = () => {
-      loadTasks();
-      loadCategories();
-    };
-    const catHandler = () => loadCategories();
-    window.addEventListener('tasks:updated', taskHandler);
-    window.addEventListener('categories:updated', catHandler);
-    return () => {
-      window.removeEventListener('tasks:updated', taskHandler);
-      window.removeEventListener('categories:updated', catHandler);
-    };
-  }, []);
 
   const nameMap = useMemo(() => {
     const map = new Map<string, string>();

--- a/src/components/CategoryManager.test.tsx
+++ b/src/components/CategoryManager.test.tsx
@@ -1,17 +1,16 @@
-import { describe, it, beforeEach, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CategoryManager from './CategoryManager';
-
-const STORAGE_KEY = 'goal-steps:categories';
+import type { Category } from '~/types';
 
 describe('CategoryManager', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('creates a category and stores it in localStorage', () => {
-    render(<CategoryManager />);
+  it('creates a category via callback', () => {
+    const categories: Category[] = [];
+    const handleAdd = (c: Category) => categories.push(c);
+    const { rerender } = render(
+      <CategoryManager categories={categories} onAdd={handleAdd} />,
+    );
 
     fireEvent.change(screen.getByLabelText('カテゴリー名'), {
       target: { value: '国語ワーク' },
@@ -28,29 +27,20 @@ describe('CategoryManager', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '追加' }));
 
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
-    expect(Array.isArray(stored)).toBe(true);
-    expect(stored.length).toBe(1);
-    expect(stored[0].name).toBe('国語ワーク');
-    expect(stored[0].minAmount).toBe(20);
-    expect(stored[0].maxAmount).toBe(60);
-    expect(stored[0].minUnit).toBe(2);
-
-    // Listed on screen
+    expect(categories.length).toBe(1);
+    rerender(<CategoryManager categories={categories} onAdd={handleAdd} />);
     expect(screen.getByText('国語ワーク')).toBeInTheDocument();
     expect(screen.getByText(/量: 20 - 60 \/ 最小単位: 2/)).toBeInTheDocument();
   });
 
   it('shows inline validation errors when fields are invalid', async () => {
-    render(<CategoryManager />);
+    render(<CategoryManager categories={[]} onAdd={() => {}} />);
 
-    // name required
     const nameInput = screen.getByLabelText('カテゴリー名');
     nameInput.focus();
     nameInput.blur();
     expect(await screen.findByText('必須です')).toBeInTheDocument();
 
-    // range validation: min > max
     fireEvent.change(screen.getByLabelText('カテゴリー名'), {
       target: { value: 'チェック' },
     });
@@ -61,21 +51,18 @@ describe('CategoryManager', () => {
     fireEvent.change(screen.getByLabelText('最小単位'), { target: { value: '1' } });
     fireEvent.blur(screen.getByLabelText('最小単位'));
 
-    // Both min and max should show range error
     const msgs = await screen.findAllByText('最小は最大以下で入力してください');
     expect(msgs.length).toBeGreaterThanOrEqual(2);
   });
 
   it('validates category deadline against project deadline (must be earlier or same day)', async () => {
-    // Set project deadline in localStorage
     localStorage.setItem(
       'goal-steps:project-settings',
-      JSON.stringify({ name: 'P', deadline: '2025-12-31' })
+      JSON.stringify({ name: 'P', deadline: '2025-12-31' }),
     );
 
-    render(<CategoryManager />);
+    render(<CategoryManager categories={[]} onAdd={() => {}} />);
 
-    // Fill required fields minimally to enable validation state
     fireEvent.change(screen.getByLabelText('カテゴリー名'), {
       target: { value: '締切チェック' },
     });
@@ -83,7 +70,6 @@ describe('CategoryManager', () => {
     fireEvent.change(screen.getByLabelText('量（最大）'), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText('最小単位'), { target: { value: '1' } });
 
-    // Set category deadline after project deadline
     const dl = screen.getByLabelText('カテゴリー期限（任意）');
     fireEvent.change(dl, {
       target: { value: '2026-01-01' },
@@ -91,20 +77,17 @@ describe('CategoryManager', () => {
     fireEvent.blur(dl);
 
     expect(
-      await screen.findByText('プロジェクト期限以前の日付を入力してください')
+      await screen.findByText('プロジェクト期限以前の日付を入力してください'),
     ).toBeInTheDocument();
 
-    // Fix to same day (allowed)
     fireEvent.change(screen.getByLabelText('カテゴリー期限（任意）'), {
       target: { value: '2025-12-31' },
     });
-
-    // Blur again to revalidate
     fireEvent.blur(screen.getByLabelText('カテゴリー期限（任意）'));
 
-    // Error should disappear
     expect(
-      screen.queryByText('プロジェクト期限以前の日付を入力してください')
+      screen.queryByText('プロジェクト期限以前の日付を入力してください'),
     ).not.toBeInTheDocument();
   });
 });
+

--- a/src/components/CategoryManager.tsx
+++ b/src/components/CategoryManager.tsx
@@ -1,33 +1,25 @@
 import { useEffect, useMemo, useState, type FC, type FormEvent, useCallback } from 'react';
 import type { Category } from '~/types';
 
-const STORAGE_KEY = 'goal-steps:categories';
-
 const nowIso = () => new Date().toISOString();
 const uid = () => Math.random().toString(36).slice(2, 10);
 
-const CategoryManager: FC = () => {
+interface Props {
+  categories: Category[];
+  onAdd: (category: Category) => void;
+}
+
+const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
   const [name, setName] = useState('');
   const [minAmount, setMinAmount] = useState<number | ''>('');
   const [maxAmount, setMaxAmount] = useState<number | ''>('');
   const [minUnit, setMinUnit] = useState<number | ''>(1);
   const [deadline, setDeadline] = useState<string>('');
   const [projectDeadline, setProjectDeadline] = useState<string | null>(null);
-
-  const [categories, setCategories] = useState<Category[]>([]);
   const [touched, setTouched] = useState({ name: false, min: false, max: false, unit: false, deadline: false });
   const [submitted, setSubmitted] = useState(false);
 
   useEffect(() => {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      try {
-        const parsed = JSON.parse(raw) as Category[];
-        setCategories(parsed);
-      } catch {
-        // noop
-      }
-    }
     const projRaw = localStorage.getItem('goal-steps:project-settings');
     if (projRaw) {
       try {
@@ -74,12 +66,6 @@ const CategoryManager: FC = () => {
     setSubmitted(false);
   };
 
-  const persist = (next: Category[]) => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-    setCategories(next);
-    window.dispatchEvent(new Event('categories:updated'));
-  };
-
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSubmitted(true);
@@ -95,8 +81,7 @@ const CategoryManager: FC = () => {
       createdAt: ts,
       updatedAt: ts,
     };
-    const next = [...categories, item];
-    persist(next);
+    onAdd(item);
     resetForm();
   };
 

--- a/src/lib/autoAllocate.ts
+++ b/src/lib/autoAllocate.ts
@@ -87,7 +87,6 @@ export function autoAllocateTasks(today = new Date()): TaskBlock[] {
   }
 
   localStorage.setItem(TASK_KEY, JSON.stringify(tasks));
-  window.dispatchEvent(new Event('tasks:updated'));
   return tasks;
 }
 

--- a/src/pages/PlannerPage.test.tsx
+++ b/src/pages/PlannerPage.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlannerPage from './PlannerPage';
+
+describe('PlannerPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('allows adding categories and planning tasks', () => {
+    localStorage.setItem(
+      'goal-steps:project-settings',
+      JSON.stringify({ name: 'P', deadline: '2025-12-31' }),
+    );
+    render(<PlannerPage />);
+    fireEvent.change(screen.getByLabelText('カテゴリー名'), { target: { value: '国語' } });
+    fireEvent.change(screen.getByLabelText('量（最小）'), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText('量（最大）'), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText('最小単位'), { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+    expect(screen.getByText('国語')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '自動計画を作成' }));
+    expect(screen.getByText(/タスクを\d+件作成しました/)).toBeInTheDocument();
+  });
+});
+

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState, type FC } from 'react';
+import ProjectSettingsForm from '~/components/ProjectSettingsForm';
+import CategoryManager from '~/components/CategoryManager';
+import AutoPlanButton from '~/components/AutoPlanButton';
+import CalendarView from '~/components/CalendarView';
+import autoAllocateTasks from '~/lib/autoAllocate';
+import type { Category, TaskBlock } from '~/types';
+
+const CAT_KEY = 'goal-steps:categories';
+const TASK_KEY = 'goal-steps:tasks';
+
+const PlannerPage: FC = () => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [tasks, setTasks] = useState<TaskBlock[]>([]);
+
+  useEffect(() => {
+    const catRaw = localStorage.getItem(CAT_KEY);
+    if (catRaw) {
+      try {
+        setCategories(JSON.parse(catRaw) as Category[]);
+      } catch {
+        // noop
+      }
+    }
+    const taskRaw = localStorage.getItem(TASK_KEY);
+    if (taskRaw) {
+      try {
+        setTasks(JSON.parse(taskRaw) as TaskBlock[]);
+      } catch {
+        // noop
+      }
+    }
+  }, []);
+
+  const handleAddCategory = (c: Category) => {
+    const next = [...categories, c];
+    setCategories(next);
+    localStorage.setItem(CAT_KEY, JSON.stringify(next));
+  };
+
+  const handlePlan = () => {
+    const generated = autoAllocateTasks();
+    setTasks(generated);
+    return generated.length;
+  };
+
+  return (
+    <div className="min-h-screen p-6 md:p-10">
+      <header className="mx-auto max-w-5xl">
+        <h1 className="text-2xl md:text-3xl font-bold">goal-steps</h1>
+        <p className="text-sm text-gray-600 mt-1">目標達成のためのタスク管理を補助するアプリ</p>
+      </header>
+      <main className="mx-auto mt-8 max-w-5xl">
+        <ProjectSettingsForm />
+        <CategoryManager categories={categories} onAdd={handleAddCategory} />
+        <AutoPlanButton onPlan={handlePlan} />
+        <CalendarView tasks={tasks} categories={categories} />
+      </main>
+    </div>
+  );
+};
+
+export default PlannerPage;
+


### PR DESCRIPTION
## Summary
- centralize state in new PlannerPage
- replace window events with prop callbacks
- adjust tests for new structure

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c34d7a1568832d9cdb6f7230060286