### PR TITLE
カテゴリーの編集・削除機能を追加

### DIFF
--- a/src/components/CategoryManager.test.tsx
+++ b/src/components/CategoryManager.test.tsx
@@ -9,7 +9,12 @@ describe('CategoryManager', () => {
     const categories: Category[] = [];
     const handleAdd = (c: Category) => categories.push(c);
     const { rerender } = render(
-      <CategoryManager categories={categories} onAdd={handleAdd} />,
+      <CategoryManager
+        categories={categories}
+        onAdd={handleAdd}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+      />,
     );
 
     fireEvent.change(screen.getByLabelText('カテゴリー名'), {
@@ -28,13 +33,27 @@ describe('CategoryManager', () => {
     fireEvent.click(screen.getByRole('button', { name: '追加' }));
 
     expect(categories.length).toBe(1);
-    rerender(<CategoryManager categories={categories} onAdd={handleAdd} />);
+    rerender(
+      <CategoryManager
+        categories={categories}
+        onAdd={handleAdd}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+      />,
+    );
     expect(screen.getByText('国語ワーク')).toBeInTheDocument();
     expect(screen.getByText(/量: 20 - 60 \/ 最小単位: 2/)).toBeInTheDocument();
   });
 
   it('shows inline validation errors when fields are invalid', async () => {
-    render(<CategoryManager categories={[]} onAdd={() => {}} />);
+    render(
+      <CategoryManager
+        categories={[]}
+        onAdd={() => {}}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+      />,
+    );
 
     const nameInput = screen.getByLabelText('カテゴリー名');
     nameInput.focus();
@@ -61,7 +80,14 @@ describe('CategoryManager', () => {
       JSON.stringify({ name: 'P', deadline: '2025-12-31' }),
     );
 
-    render(<CategoryManager categories={[]} onAdd={() => {}} />);
+    render(
+      <CategoryManager
+        categories={[]}
+        onAdd={() => {}}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+      />,
+    );
 
     fireEvent.change(screen.getByLabelText('カテゴリー名'), {
       target: { value: '締切チェック' },
@@ -88,6 +114,95 @@ describe('CategoryManager', () => {
     expect(
       screen.queryByText('プロジェクト期限以前の日付を入力してください'),
     ).not.toBeInTheDocument();
+  });
+
+  it('allows editing an existing category', () => {
+    const categories: Category[] = [
+      {
+        id: 'a',
+        name: '国語',
+        minAmount: 1,
+        maxAmount: 3,
+        minUnit: 1,
+        createdAt: 't',
+        updatedAt: 't',
+      },
+    ];
+    const handleUpdate = (c: Category) => {
+      categories[0] = c;
+    };
+    const { rerender } = render(
+      <CategoryManager
+        categories={categories}
+        onAdd={() => {}}
+        onUpdate={handleUpdate}
+        onDelete={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '編集' }));
+    fireEvent.change(screen.getByLabelText('カテゴリー名'), {
+      target: { value: '数学' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+    expect(categories[0].name).toBe('数学');
+    rerender(
+      <CategoryManager
+        categories={categories}
+        onAdd={() => {}}
+        onUpdate={handleUpdate}
+        onDelete={() => {}}
+      />,
+    );
+    expect(screen.getByText('数学')).toBeInTheDocument();
+  });
+
+  it('allows deleting a category', () => {
+    const categories: Category[] = [
+      {
+        id: 'a',
+        name: '国語',
+        minAmount: 1,
+        maxAmount: 3,
+        minUnit: 1,
+        createdAt: 't',
+        updatedAt: 't',
+      },
+      {
+        id: 'b',
+        name: '数学',
+        minAmount: 1,
+        maxAmount: 3,
+        minUnit: 1,
+        createdAt: 't',
+        updatedAt: 't',
+      },
+    ];
+    const handleDelete = (id: string) => {
+      const idx = categories.findIndex((c) => c.id === id);
+      if (idx >= 0) categories.splice(idx, 1);
+    };
+    const { rerender } = render(
+      <CategoryManager
+        categories={categories}
+        onAdd={() => {}}
+        onUpdate={() => {}}
+        onDelete={handleDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: '削除' })[0]);
+    expect(categories.length).toBe(1);
+    rerender(
+      <CategoryManager
+        categories={categories}
+        onAdd={() => {}}
+        onUpdate={() => {}}
+        onDelete={handleDelete}
+      />,
+    );
+    expect(screen.queryByText('国語')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/CategoryManager.tsx
+++ b/src/components/CategoryManager.tsx
@@ -7,9 +7,11 @@ const uid = () => Math.random().toString(36).slice(2, 10);
 interface Props {
   categories: Category[];
   onAdd: (category: Category) => void;
+  onUpdate: (category: Category) => void;
+  onDelete: (id: string) => void;
 }
 
-const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
+const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) => {
   const [name, setName] = useState('');
   const [minAmount, setMinAmount] = useState<number | ''>('');
   const [maxAmount, setMaxAmount] = useState<number | ''>('');
@@ -18,6 +20,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
   const [projectDeadline, setProjectDeadline] = useState<string | null>(null);
   const [touched, setTouched] = useState({ name: false, min: false, max: false, unit: false, deadline: false });
   const [submitted, setSubmitted] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   useEffect(() => {
     const projRaw = localStorage.getItem('goal-steps:project-settings');
@@ -64,6 +67,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
     setDeadline('');
     setTouched({ name: false, min: false, max: false, unit: false, deadline: false });
     setSubmitted(false);
+    setEditingId(null);
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -71,17 +75,32 @@ const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
     setSubmitted(true);
     if (!valid) return;
     const ts = nowIso();
-    const item: Category = {
-      id: uid(),
-      name: name.trim(),
-      minAmount: Number(minAmount),
-      maxAmount: Number(maxAmount),
-      minUnit: Number(minUnit),
-      deadline: deadline || undefined,
-      createdAt: ts,
-      updatedAt: ts,
-    };
-    onAdd(item);
+    if (editingId) {
+      const base = categories.find((c) => c.id === editingId);
+      if (!base) return;
+      const item: Category = {
+        ...base,
+        name: name.trim(),
+        minAmount: Number(minAmount),
+        maxAmount: Number(maxAmount),
+        minUnit: Number(minUnit),
+        deadline: deadline || undefined,
+        updatedAt: ts,
+      };
+      onUpdate(item);
+    } else {
+      const item: Category = {
+        id: uid(),
+        name: name.trim(),
+        minAmount: Number(minAmount),
+        maxAmount: Number(maxAmount),
+        minUnit: Number(minUnit),
+        deadline: deadline || undefined,
+        createdAt: ts,
+        updatedAt: ts,
+      };
+      onAdd(item);
+    }
     resetForm();
   };
 
@@ -89,9 +108,20 @@ const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
     setTouched((t) => ({ ...t, [key]: true }));
   }, []);
 
+  const startEdit = (c: Category) => {
+    setEditingId(c.id);
+    setName(c.name);
+    setMinAmount(c.minAmount);
+    setMaxAmount(c.maxAmount);
+    setMinUnit(c.minUnit);
+    setDeadline(c.deadline ?? '');
+    setTouched({ name: false, min: false, max: false, unit: false, deadline: false });
+    setSubmitted(false);
+  };
+
   return (
     <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="カテゴリー管理">
-      <h2 className="text-lg font-semibold mb-4">カテゴリーの追加</h2>
+      <h2 className="text-lg font-semibold mb-4">{editingId ? 'カテゴリーの編集' : 'カテゴリーの追加'}</h2>
       <form onSubmit={handleSubmit} className="grid gap-4 md:grid-cols-2" aria-label="カテゴリー作成フォーム">
         <div>
           <label htmlFor="cat-name" className="block text-sm font-medium">カテゴリー名</label>
@@ -186,14 +216,23 @@ const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
           )}
         </div>
 
-        <div className="md:col-span-2">
+        <div className="md:col-span-2 flex gap-2">
           <button
             type="submit"
-            className="rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700"
+            className="rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700 disabled:opacity-50"
             disabled={!valid}
           >
-            追加
+            {editingId ? '更新' : '追加'}
           </button>
+          {editingId && (
+            <button
+              type="button"
+              className="rounded border px-3 py-1.5"
+              onClick={resetForm}
+            >
+              キャンセル
+            </button>
+          )}
         </div>
       </form>
 
@@ -211,6 +250,22 @@ const CategoryManager: FC<Props> = ({ categories, onAdd }) => {
                     量: {c.minAmount} - {c.maxAmount} / 最小単位: {c.minUnit}
                     {c.deadline ? ` / 期限: ${c.deadline}` : ''}
                   </p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="rounded border px-2 py-1 text-sm"
+                    onClick={() => startEdit(c)}
+                  >
+                    編集
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border px-2 py-1 text-sm text-red-600"
+                    onClick={() => onDelete(c.id)}
+                  >
+                    削除
+                  </button>
                 </div>
               </li>
             ))}

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -38,6 +38,21 @@ const PlannerPage: FC = () => {
     localStorage.setItem(CAT_KEY, JSON.stringify(next));
   };
 
+  const handleUpdateCategory = (c: Category) => {
+    const next = categories.map((x) => (x.id === c.id ? c : x));
+    setCategories(next);
+    localStorage.setItem(CAT_KEY, JSON.stringify(next));
+  };
+
+  const handleDeleteCategory = (id: string) => {
+    const next = categories.filter((c) => c.id !== id);
+    setCategories(next);
+    localStorage.setItem(CAT_KEY, JSON.stringify(next));
+    const nextTasks = tasks.filter((t) => t.categoryId !== id);
+    setTasks(nextTasks);
+    localStorage.setItem(TASK_KEY, JSON.stringify(nextTasks));
+  };
+
   const handlePlan = () => {
     const generated = autoAllocateTasks();
     setTasks(generated);
@@ -52,7 +67,12 @@ const PlannerPage: FC = () => {
       </header>
       <main className="mx-auto mt-8 max-w-5xl">
         <ProjectSettingsForm />
-        <CategoryManager categories={categories} onAdd={handleAddCategory} />
+        <CategoryManager
+          categories={categories}
+          onAdd={handleAddCategory}
+          onUpdate={handleUpdateCategory}
+          onDelete={handleDeleteCategory}
+        />
         <AutoPlanButton onPlan={handlePlan} />
         <CalendarView tasks={tasks} categories={categories} />
       </main>


### PR DESCRIPTION
## Summary
- カテゴリー管理画面で既存カテゴリーの編集・削除をサポート
- プランナーページでカテゴリー更新・削除時に状態とLocalStorageを同期
- カテゴリー編集・削除のユニットテストを追加

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3539f64d4832d85a78635108f3fb8