### PR TITLE
feat: display weekday headers in calendar

### DIFF
--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -13,10 +13,23 @@ describe('CalendarView', () => {
         initialDate={new Date('2025-01-01')}
       />,
     );
-    const names = ['日', '月', '火', '水', '木', '金', '土'];
+    const names = ['月', '火', '水', '木', '金', '土', '日'];
     for (const n of names) {
       expect(screen.getByText(n)).toBeInTheDocument();
     }
+  });
+
+  it('aligns first day to correct weekday with Monday start', () => {
+    render(
+      <CalendarView
+        tasks={[]}
+        categories={[]}
+        initialDate={new Date('2025-01-01')}
+      />,
+    );
+    const grid = screen.getByRole('grid');
+    const cells = within(grid).getAllByRole('gridcell', { hidden: true });
+    expect(cells[2]).toHaveAttribute('aria-label', '2025-01-01');
   });
 
   it('displays tasks on corresponding dates', () => {

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -5,6 +5,20 @@ import CalendarView from './CalendarView';
 import type { Category, TaskBlock } from '~/types';
 
 describe('CalendarView', () => {
+  it('renders day names', () => {
+    render(
+      <CalendarView
+        tasks={[]}
+        categories={[]}
+        initialDate={new Date('2025-01-01')}
+      />,
+    );
+    const names = ['日', '月', '火', '水', '木', '金', '土'];
+    for (const n of names) {
+      expect(screen.getByText(n)).toBeInTheDocument();
+    }
+  });
+
   it('displays tasks on corresponding dates', () => {
     const categories: Category[] = [
       {

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -13,10 +13,13 @@ describe('CalendarView', () => {
         initialDate={new Date('2025-01-01')}
       />,
     );
-    const names = ['月', '火', '水', '木', '金', '土', '日'];
-    for (const n of names) {
-      expect(screen.getByText(n)).toBeInTheDocument();
-    }
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(7);
+    const texts = headers.map((h) => h.textContent);
+    expect(texts).toEqual(['月', '火', '水', '木', '金', '土', '日']);
+    headers.forEach((h) => {
+      expect(h).toHaveAttribute('aria-label');
+    });
   });
 
   it('aligns first day to correct weekday with Monday start', () => {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -8,6 +8,8 @@ const formatDate = (year: number, month: number, day: number) => {
   return `${year}-${m}-${d}`;
 };
 
+const DAY_NAMES = ['月', '火', '水', '木', '金', '土', '日'] as const;
+
 interface Props {
   tasks: TaskBlock[];
   categories: Category[];
@@ -29,7 +31,6 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
   const year = current.getFullYear();
   const month = current.getMonth();
   const days = daysInMonth(year, month);
-  const dayNames = ['月', '火', '水', '木', '金', '土', '日'];
   const firstDay = new Date(year, month, 1).getDay();
   const startOffset = (firstDay + 6) % 7;
 
@@ -100,8 +101,8 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
         </div>
       </div>
       <div className="mb-1 grid grid-cols-7 text-center text-sm font-semibold" role="row">
-        {dayNames.map((d) => (
-          <div key={d} role="columnheader">
+        {DAY_NAMES.map((d) => (
+          <div key={d} role="columnheader" aria-label={`${d}曜日`}>
             {d}
           </div>
         ))}

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -29,6 +29,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
   const year = current.getFullYear();
   const month = current.getMonth();
   const days = daysInMonth(year, month);
+  const dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 
   const prevMonth = () => setCurrent(new Date(year, month - 1, 1));
   const nextMonth = () => setCurrent(new Date(year, month + 1, 1));
@@ -76,6 +77,13 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
             次
           </button>
         </div>
+      </div>
+      <div className="mb-1 grid grid-cols-7 text-center text-sm font-semibold" role="row">
+        {dayNames.map((d) => (
+          <div key={d} role="columnheader">
+            {d}
+          </div>
+        ))}
       </div>
       <div role="grid" className="grid grid-cols-7 gap-px bg-gray-300">
         {cells}

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, type FC } from 'react';
+import { useState, useMemo, type FC, type ReactElement } from 'react';
 import type { TaskBlock, Category } from '~/types';
 
 const daysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
@@ -29,7 +29,9 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
   const year = current.getFullYear();
   const month = current.getMonth();
   const days = daysInMonth(year, month);
-  const dayNames = ['日', '月', '火', '水', '木', '金', '土'];
+  const dayNames = ['月', '火', '水', '木', '金', '土', '日'];
+  const firstDay = new Date(year, month, 1).getDay();
+  const startOffset = (firstDay + 6) % 7;
 
   const prevMonth = () => setCurrent(new Date(year, month - 1, 1));
   const nextMonth = () => setCurrent(new Date(year, month + 1, 1));
@@ -44,12 +46,23 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
     grouped[t.date].push(t);
   }
 
-  const cells = [];
+  const cells: ReactElement[] = [];
+  for (let i = 0; i < startOffset; i++) {
+    cells.push(
+      <div key={`pre-${i}`} role="gridcell" className="h-24 border bg-gray-50" aria-hidden="true" />,
+    );
+  }
+
   for (let day = 1; day <= days; day++) {
     const dateStr = formatDate(year, month, day);
     const ts = grouped[dateStr] || [];
     cells.push(
-      <div key={dateStr} role="gridcell" aria-label={dateStr} className="h-24 border p-1 overflow-y-auto bg-white">
+      <div
+        key={dateStr}
+        role="gridcell"
+        aria-label={dateStr}
+        className="h-24 border p-1 overflow-y-auto bg-white"
+      >
         <div className="text-xs">{day}</div>
         {ts.map((t) => (
           <div key={t.id} data-testid="task-block" className="mt-1 rounded bg-blue-100 p-1 text-xs">
@@ -57,6 +70,14 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
           </div>
         ))}
       </div>,
+    );
+  }
+
+  const totalCells = cells.length;
+  const endOffset = (7 - (totalCells % 7)) % 7;
+  for (let i = 0; i < endOffset; i++) {
+    cells.push(
+      <div key={`post-${i}`} role="gridcell" className="h-24 border bg-gray-50" aria-hidden="true" />,
     );
   }
 


### PR DESCRIPTION
## Summary
- show day-of-week headers above calendar grid
- test for weekday header rendering

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c3540d9c40832da57d95dd134e67f7