### PR TITLE
feat: enable task completion with progress

### DIFF
--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CalendarView from './CalendarView';
 import type { Category, TaskBlock } from '~/types';
+import { useState, type FC } from 'react';
 
 describe('CalendarView', () => {
   it('renders day names', () => {
@@ -123,6 +124,44 @@ describe('CalendarView', () => {
     );
     const cell = screen.getByLabelText('2025-01-15');
     expect(within(cell).getByText('カテゴリ2: 4')).toBeInTheDocument();
+  });
+
+  it('toggles task completion', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const initial: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+    ];
+
+    const Wrapper: FC = () => {
+      const [ts, setTs] = useState<TaskBlock[]>(initial);
+      return (
+        <CalendarView
+          tasks={ts}
+          categories={categories}
+          initialDate={new Date('2025-01-01')}
+          onToggleTask={(id) =>
+            setTs((prev) => prev.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)))
+          }
+        />
+      );
+    };
+
+    render(<Wrapper />);
+    const cell = screen.getByLabelText('2025-01-05');
+    const block = within(cell).getByTestId('task-block');
+    expect(block).not.toHaveClass('opacity-50');
+    fireEvent.click(within(block).getByRole('checkbox'));
+    expect(block).toHaveClass('opacity-50');
   });
 });
 

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -14,9 +14,10 @@ interface Props {
   tasks: TaskBlock[];
   categories: Category[];
   initialDate?: Date;
+  onToggleTask?: (id: string) => void;
 }
 
-const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
+const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask }) => {
   const [current, setCurrent] = useState(() => {
     const d = initialDate ?? new Date();
     return new Date(d.getFullYear(), d.getMonth(), 1);
@@ -66,8 +67,22 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate }) => {
       >
         <div className="text-xs">{day}</div>
         {ts.map((t) => (
-          <div key={t.id} data-testid="task-block" className="mt-1 rounded bg-blue-100 p-1 text-xs">
-            {nameMap.get(t.categoryId) ?? t.categoryId}: {t.amount}
+          <div
+            key={t.id}
+            data-testid="task-block"
+            className={`mt-1 rounded p-1 text-xs ${t.completed ? 'bg-green-100 opacity-50' : 'bg-blue-100'}`}
+          >
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={t.completed}
+                onChange={() => onToggleTask?.(t.id)}
+                aria-label="完了"
+              />
+              <span className={t.completed ? 'line-through' : undefined}>
+                {nameMap.get(t.categoryId) ?? t.categoryId}: {t.amount}
+              </span>
+            </label>
           </div>
         ))}
       </div>,

--- a/src/pages/PlannerPage.test.tsx
+++ b/src/pages/PlannerPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PlannerPage from './PlannerPage';
 
@@ -23,6 +23,35 @@ describe('PlannerPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '自動計画を作成' }));
     expect(screen.getByText(/タスクを\d+件作成しました/)).toBeInTheDocument();
+  });
+
+  it('updates progress when toggling task completion', async () => {
+    localStorage.setItem(
+      'goal-steps:project-settings',
+      JSON.stringify({ name: 'P', deadline: '2025-12-31' }),
+    );
+    const categories = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    localStorage.setItem('goal-steps:categories', JSON.stringify(categories));
+    const today = new Date().toISOString().slice(0, 10);
+    const tasks = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: today, completed: false },
+    ];
+    localStorage.setItem('goal-steps:tasks', JSON.stringify(tasks));
+    render(<PlannerPage />);
+    expect(await screen.findByText('進捗率: 0%')).toBeInTheDocument();
+    const block = await screen.findByTestId('task-block');
+    fireEvent.click(within(block).getByRole('checkbox'));
+    expect(await screen.findByText('進捗率: 100%')).toBeInTheDocument();
   });
 });
 

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -56,8 +56,18 @@ const PlannerPage: FC = () => {
   const handlePlan = () => {
     const generated = autoAllocateTasks();
     setTasks(generated);
+    localStorage.setItem(TASK_KEY, JSON.stringify(generated));
     return generated.length;
   };
+
+  const handleToggleTask = (id: string) => {
+    const next = tasks.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t));
+    setTasks(next);
+    localStorage.setItem(TASK_KEY, JSON.stringify(next));
+  };
+
+  const completed = tasks.filter((t) => t.completed).length;
+  const progress = tasks.length ? Math.round((completed / tasks.length) * 100) : 0;
 
   return (
     <div className="min-h-screen p-6 md:p-10">
@@ -74,7 +84,12 @@ const PlannerPage: FC = () => {
           onDelete={handleDeleteCategory}
         />
         <AutoPlanButton onPlan={handlePlan} />
-        <CalendarView tasks={tasks} categories={categories} />
+        {tasks.length > 0 && (
+          <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="進捗">
+            <p>進捗率: {progress}%</p>
+          </section>
+        )}
+        <CalendarView tasks={tasks} categories={categories} onToggleTask={handleToggleTask} />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow toggling task blocks as completed
- persist task completion and show overall progress
- add unit tests for task completion and progress updates

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c35e7278c8832d9186b7dfceb3952c