### PR TITLE
feat: enable manual task adjustment

### DIFF
--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -214,4 +214,49 @@ describe('CalendarView', () => {
 
     expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
   });
+
+  it('moves task via touch interaction', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const initial: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+    ];
+
+    const Wrapper: FC = () => {
+      const [ts, setTs] = useState<TaskBlock[]>(initial);
+      return (
+        <CalendarView
+          tasks={ts}
+          categories={categories}
+          initialDate={new Date('2025-01-01')}
+          onMoveTask={(id, date) =>
+            setTs((prev) => prev.map((t) => (t.id === id ? { ...t, date } : t)))
+          }
+        />
+      );
+    };
+
+    render(<Wrapper />);
+
+    const block = screen.getByTestId('task-block');
+    const targetCell = screen.getByLabelText('2025-01-06');
+    const doc = document as { elementFromPoint: (x: number, y: number) => Element | null };
+    const original = doc.elementFromPoint;
+    doc.elementFromPoint = () => targetCell;
+
+    fireEvent.touchStart(block, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchEnd(document, { changedTouches: [{ clientX: 10, clientY: 10 }] });
+
+    doc.elementFromPoint = original;
+    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+  });
 });

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CalendarView from './CalendarView';
@@ -134,6 +134,39 @@ describe('CalendarView', () => {
     expect(block).not.toHaveClass('opacity-50');
     fireEvent.click(within(block).getByRole('checkbox'));
     expect(block).toHaveClass('opacity-50');
+  });
+
+  it('does not toggle completion in move mode', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const tasks: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+    ];
+    const toggle = vi.fn();
+    render(
+      <CalendarView
+        tasks={tasks}
+        categories={categories}
+        initialDate={new Date('2025-01-01')}
+        onToggleTask={toggle}
+      />,
+    );
+    const moveBtn = screen.getByRole('button', { name: 'タスク移動モード' });
+    fireEvent.click(moveBtn);
+    const cell = screen.getByLabelText('2025-01-05');
+    const block = within(cell).getByTestId('task-block');
+    fireEvent.click(within(block).getByText('カテゴリ1: 1'));
+    expect(toggle).not.toHaveBeenCalled();
+    expect(block).not.toHaveClass('opacity-50');
   });
 
   it('prevents dragging completed tasks', () => {

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -259,4 +259,47 @@ describe('CalendarView', () => {
     doc.elementFromPoint = original;
     expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
   });
+
+  it('moves task via move mode selection', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const initial: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+    ];
+
+    const Wrapper: FC = () => {
+      const [ts, setTs] = useState<TaskBlock[]>(initial);
+      return (
+        <CalendarView
+          tasks={ts}
+          categories={categories}
+          initialDate={new Date('2025-01-01')}
+          onMoveTask={(id, date) =>
+            setTs((prev) => prev.map((t) => (t.id === id ? { ...t, date } : t)))
+          }
+        />
+      );
+    };
+
+    render(<Wrapper />);
+
+    const moveBtn = screen.getByRole('button', { name: 'タスク移動モード' });
+    fireEvent.click(moveBtn);
+    const sourceCell = screen.getByLabelText('2025-01-05');
+    const block = within(sourceCell).getByTestId('task-block');
+    fireEvent.click(block);
+    const targetCell = screen.getByLabelText('2025-01-06');
+    fireEvent.click(targetCell);
+
+    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+  });
 });

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -7,13 +7,7 @@ import { useState, type FC } from 'react';
 
 describe('CalendarView', () => {
   it('renders day names', () => {
-    render(
-      <CalendarView
-        tasks={[]}
-        categories={[]}
-        initialDate={new Date('2025-01-01')}
-      />,
-    );
+    render(<CalendarView tasks={[]} categories={[]} initialDate={new Date('2025-01-01')} />);
     const headers = screen.getAllByRole('columnheader');
     expect(headers).toHaveLength(7);
     const texts = headers.map((h) => h.textContent);
@@ -24,13 +18,7 @@ describe('CalendarView', () => {
   });
 
   it('aligns first day to correct weekday with Monday start', () => {
-    render(
-      <CalendarView
-        tasks={[]}
-        categories={[]}
-        initialDate={new Date('2025-01-01')}
-      />,
-    );
+    render(<CalendarView tasks={[]} categories={[]} initialDate={new Date('2025-01-01')} />);
     const grid = screen.getByRole('grid');
     const cells = within(grid).getAllByRole('gridcell', { hidden: true });
     expect(cells[2]).toHaveAttribute('aria-label', '2025-01-01');
@@ -52,11 +40,7 @@ describe('CalendarView', () => {
       { id: 't1', categoryId: 'c1', amount: 2, date: '2025-01-05', completed: false },
     ];
     render(
-      <CalendarView
-        tasks={tasks}
-        categories={categories}
-        initialDate={new Date('2025-01-01')}
-      />,
+      <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
     const cell = screen.getByLabelText('2025-01-05');
     expect(within(cell).getByText('カテゴリ1: 2')).toBeInTheDocument();
@@ -76,19 +60,11 @@ describe('CalendarView', () => {
     ];
     const tasks: TaskBlock[] = [];
     const { rerender } = render(
-      <CalendarView
-        tasks={tasks}
-        categories={categories}
-        initialDate={new Date('2025-01-01')}
-      />,
+      <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
     tasks.push({ id: 't2', categoryId: 'c1', amount: 3, date: '2025-01-10', completed: false });
     rerender(
-      <CalendarView
-        tasks={tasks}
-        categories={categories}
-        initialDate={new Date('2025-01-01')}
-      />,
+      <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
     const cell = screen.getByLabelText('2025-01-10');
     expect(within(cell).getByText('カテゴリ1: 3')).toBeInTheDocument();
@@ -100,11 +76,7 @@ describe('CalendarView', () => {
       { id: 't3', categoryId: 'c2', amount: 4, date: '2025-01-15', completed: false },
     ];
     const { rerender } = render(
-      <CalendarView
-        tasks={tasks}
-        categories={categories}
-        initialDate={new Date('2025-01-01')}
-      />,
+      <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
     categories.push({
       id: 'c2',
@@ -163,5 +135,83 @@ describe('CalendarView', () => {
     fireEvent.click(within(block).getByRole('checkbox'));
     expect(block).toHaveClass('opacity-50');
   });
-});
 
+  it('prevents dragging completed tasks', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const tasks: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: true },
+    ];
+    render(
+      <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
+    );
+    const block = screen.getByTestId('task-block');
+    expect(block).not.toHaveAttribute('draggable', 'true');
+  });
+
+  it('allows dragging incomplete task to another date', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const initial: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+    ];
+
+    const Wrapper: FC = () => {
+      const [ts, setTs] = useState<TaskBlock[]>(initial);
+      return (
+        <CalendarView
+          tasks={ts}
+          categories={categories}
+          initialDate={new Date('2025-01-01')}
+          onMoveTask={(id, date) =>
+            setTs((prev) => prev.map((t) => (t.id === id ? { ...t, date } : t)))
+          }
+        />
+      );
+    };
+
+    render(<Wrapper />);
+
+    const block = screen.getByTestId('task-block');
+    const targetCell = screen.getByLabelText('2025-01-06');
+    const store: { value?: string } = {};
+    const data = {
+      dropEffect: 'none',
+      effectAllowed: 'all',
+      files: {} as FileList,
+      items: {} as DataTransferItemList,
+      types: [] as string[],
+      setData: (_: string, value: string) => {
+        store.value = value;
+      },
+      getData: () => store.value ?? '',
+      clearData: () => {
+        store.value = undefined;
+      },
+      setDragImage: () => {},
+    } as DataTransfer;
+    fireEvent.dragStart(block, { dataTransfer: data });
+    fireEvent.dragOver(targetCell, { dataTransfer: data });
+    fireEvent.drop(targetCell, { dataTransfer: data });
+
+    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+  });
+});

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -25,6 +25,8 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
   });
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+  const [moveMode, setMoveMode] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!draggingId) return;
@@ -66,6 +68,13 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
     };
   }, [draggingId, onMoveTask]);
 
+  useEffect(() => {
+    if (moveMode) {
+      setDraggingId(null);
+      setDragOverDate(null);
+    }
+  }, [moveMode]);
+
   const nameMap = useMemo(() => {
     const map = new Map<string, string>();
     for (const c of categories) map.set(c.id, c.name);
@@ -83,6 +92,12 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
   const goToday = () => {
     const t = new Date();
     setCurrent(new Date(t.getFullYear(), t.getMonth(), 1));
+  };
+  const toggleMoveMode = () => {
+    setMoveMode((prev) => {
+      if (prev) setSelectedId(null);
+      return !prev;
+    });
   };
 
   const grouped: Record<string, TaskBlock[]> = {};
@@ -127,27 +142,45 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
           setDragOverDate(null);
           setDraggingId(null);
         }}
+        onClick={() => {
+          if (moveMode && selectedId) {
+            onMoveTask?.(selectedId, dateStr);
+            setSelectedId(null);
+          }
+        }}
       >
         <div className="text-xs">{day}</div>
         {ts.map((t) => (
           <div
             key={t.id}
             data-testid="task-block"
-            draggable={!t.completed}
+            draggable={!t.completed && !moveMode}
             onDragStart={(e) => {
-              if (t.completed) return;
+              if (moveMode || t.completed) return;
               e.dataTransfer.setData('text/plain', t.id);
               setDraggingId(t.id);
             }}
             onDragEnd={() => setDraggingId(null)}
             onTouchStart={(e) => {
-              if (t.completed) return;
+              if (moveMode || t.completed) return;
               e.stopPropagation();
               setDraggingId(t.id);
             }}
+            onClick={(e) => {
+              if (!moveMode) return;
+              e.stopPropagation();
+              if (t.completed) return;
+              setSelectedId(t.id);
+            }}
             className={`mt-1 rounded p-1 text-xs ${
               t.completed ? 'bg-green-100 opacity-50' : 'bg-blue-100'
-            } ${draggingId === t.id ? 'rotate-2 ring-2 ring-blue-300' : ''}`}
+            } ${
+              draggingId === t.id
+                ? 'rotate-2 ring-2 ring-blue-300'
+                : selectedId === t.id
+                  ? 'ring-2 ring-blue-300'
+                  : ''
+            }`}
           >
             <label className="flex items-center gap-1">
               <input
@@ -212,6 +245,14 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
             className="px-2 py-1 border rounded"
           >
             次
+          </button>
+          <button
+            type="button"
+            onClick={toggleMoveMode}
+            aria-label="タスク移動モード"
+            className={`px-2 py-1 border rounded ${moveMode ? 'bg-blue-100' : ''}`}
+          >
+            {moveMode ? '移動中' : '移動モード'}
           </button>
         </div>
       </div>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -216,6 +216,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
               <input
                 type="checkbox"
                 checked={t.completed}
+                disabled={moveMode}
                 onChange={() => onToggleTask?.(t.id)}
                 aria-label="完了"
               />

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, type FC, type ReactElement } from 'react';
+import { useState, useMemo, useEffect, type FC, type ReactElement } from 'react';
 import type { TaskBlock, Category } from '~/types';
 
 const daysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
@@ -25,6 +25,37 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
   });
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!draggingId) return;
+
+    const handleMove = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      const el = document.elementFromPoint(touch.clientX, touch.clientY);
+      const cell = el?.closest('[data-date]') as HTMLDivElement | null;
+      const date = cell?.getAttribute('data-date');
+      setDragOverDate(date ?? null);
+    };
+
+    const handleEnd = (e: TouchEvent) => {
+      const touch = e.changedTouches[0];
+      if (!touch) return;
+      const el = document.elementFromPoint(touch.clientX, touch.clientY);
+      const cell = el?.closest('[data-date]') as HTMLDivElement | null;
+      const date = cell?.getAttribute('data-date');
+      if (date) onMoveTask?.(draggingId, date);
+      setDraggingId(null);
+      setDragOverDate(null);
+    };
+
+    document.addEventListener('touchmove', handleMove);
+    document.addEventListener('touchend', handleEnd);
+    return () => {
+      document.removeEventListener('touchmove', handleMove);
+      document.removeEventListener('touchend', handleEnd);
+    };
+  }, [draggingId, onMoveTask]);
 
   const nameMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -69,6 +100,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
     cells.push(
       <div
         key={dateStr}
+        data-date={dateStr}
         role="gridcell"
         aria-label={dateStr}
         className={`h-24 border p-1 overflow-y-auto bg-white ${
@@ -99,6 +131,11 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
               setDraggingId(t.id);
             }}
             onDragEnd={() => setDraggingId(null)}
+            onTouchStart={(e) => {
+              if (t.completed) return;
+              e.stopPropagation();
+              setDraggingId(t.id);
+            }}
             className={`mt-1 rounded p-1 text-xs ${
               t.completed ? 'bg-green-100 opacity-50' : 'bg-blue-100'
             } ${draggingId === t.id ? 'rotate-2 ring-2 ring-blue-300' : ''}`}

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -32,6 +32,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
     const handleMove = (e: TouchEvent) => {
       const touch = e.touches[0];
       if (!touch) return;
+      e.preventDefault();
       const el = document.elementFromPoint(touch.clientX, touch.clientY);
       const cell = el?.closest('[data-date]') as HTMLDivElement | null;
       const date = cell?.getAttribute('data-date');
@@ -41,6 +42,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
     const handleEnd = (e: TouchEvent) => {
       const touch = e.changedTouches[0];
       if (!touch) return;
+      e.preventDefault();
       const el = document.elementFromPoint(touch.clientX, touch.clientY);
       const cell = el?.closest('[data-date]') as HTMLDivElement | null;
       const date = cell?.getAttribute('data-date');
@@ -49,11 +51,18 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
       setDragOverDate(null);
     };
 
-    document.addEventListener('touchmove', handleMove);
+    const handleCancel = () => {
+      setDraggingId(null);
+      setDragOverDate(null);
+    };
+
+    document.addEventListener('touchmove', handleMove, { passive: false });
     document.addEventListener('touchend', handleEnd);
+    document.addEventListener('touchcancel', handleCancel);
     return () => {
       document.removeEventListener('touchmove', handleMove);
       document.removeEventListener('touchend', handleEnd);
+      document.removeEventListener('touchcancel', handleCancel);
     };
   }, [draggingId, onMoveTask]);
 

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,4 +1,11 @@
-import { useState, useMemo, useEffect, type FC, type ReactElement } from 'react';
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  type FC,
+  type ReactElement,
+} from 'react';
 import type { TaskBlock, Category } from '~/types';
 
 const daysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
@@ -24,9 +31,11 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
     return new Date(d.getFullYear(), d.getMonth(), 1);
   });
   const [draggingId, setDraggingId] = useState<string | null>(null);
+  const draggingIdRef = useRef<string | null>(null);
   const [dragOverDate, setDragOverDate] = useState<string | null>(null);
   const [moveMode, setMoveMode] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!draggingId) return;
@@ -48,12 +57,15 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
       const el = document.elementFromPoint(touch.clientX, touch.clientY);
       const cell = el?.closest('[data-date]') as HTMLDivElement | null;
       const date = cell?.getAttribute('data-date');
-      if (date) onMoveTask?.(draggingId, date);
+      const id = draggingIdRef.current;
+      if (date && id) onMoveTask?.(id, date);
+      draggingIdRef.current = null;
       setDraggingId(null);
       setDragOverDate(null);
     };
 
     const handleCancel = () => {
+      draggingIdRef.current = null;
       setDraggingId(null);
       setDragOverDate(null);
     };
@@ -70,6 +82,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
 
   useEffect(() => {
     if (moveMode) {
+      draggingIdRef.current = null;
       setDraggingId(null);
       setDragOverDate(null);
     }
@@ -95,7 +108,10 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
   };
   const toggleMoveMode = () => {
     setMoveMode((prev) => {
-      if (prev) setSelectedId(null);
+      if (prev) {
+        setSelectedId(null);
+        selectedIdRef.current = null;
+      }
       return !prev;
     });
   };
@@ -131,20 +147,27 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
           dragOverDate === dateStr ? 'ring-2 ring-blue-300' : ''
         }`}
         onDragOver={(e) => {
-          if (draggingId) e.preventDefault();
+          if (draggingIdRef.current) e.preventDefault();
         }}
-        onDragEnter={() => draggingId && setDragOverDate(dateStr)}
-        onDragLeave={() => dragOverDate === dateStr && setDragOverDate(null)}
+        onDragEnter={() => {
+          if (draggingIdRef.current) setDragOverDate(dateStr);
+        }}
+        onDragLeave={() => {
+          if (draggingIdRef.current && dragOverDate === dateStr) setDragOverDate(null);
+        }}
         onDrop={(e) => {
           e.preventDefault();
-          const id = e.dataTransfer.getData('text/plain');
+          const id = draggingIdRef.current || e.dataTransfer.getData('text/plain');
           if (id) onMoveTask?.(id, dateStr);
-          setDragOverDate(null);
+          draggingIdRef.current = null;
           setDraggingId(null);
+          setDragOverDate(null);
         }}
         onClick={() => {
-          if (moveMode && selectedId) {
-            onMoveTask?.(selectedId, dateStr);
+          const id = selectedIdRef.current;
+          if (moveMode && id) {
+            onMoveTask?.(id, dateStr);
+            selectedIdRef.current = null;
             setSelectedId(null);
           }
         }}
@@ -158,18 +181,25 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
             onDragStart={(e) => {
               if (moveMode || t.completed) return;
               e.dataTransfer.setData('text/plain', t.id);
+              draggingIdRef.current = t.id;
               setDraggingId(t.id);
             }}
-            onDragEnd={() => setDraggingId(null)}
+            onDragEnd={() => {
+              draggingIdRef.current = null;
+              setDraggingId(null);
+              setDragOverDate(null);
+            }}
             onTouchStart={(e) => {
               if (moveMode || t.completed) return;
               e.stopPropagation();
+              draggingIdRef.current = t.id;
               setDraggingId(t.id);
             }}
             onClick={(e) => {
               if (!moveMode) return;
               e.stopPropagation();
               if (t.completed) return;
+              selectedIdRef.current = t.id;
               setSelectedId(t.id);
             }}
             className={`mt-1 rounded p-1 text-xs ${

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -15,13 +15,16 @@ interface Props {
   categories: Category[];
   initialDate?: Date;
   onToggleTask?: (id: string) => void;
+  onMoveTask?: (id: string, date: string) => void;
 }
 
-const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask }) => {
+const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask, onMoveTask }) => {
   const [current, setCurrent] = useState(() => {
     const d = initialDate ?? new Date();
     return new Date(d.getFullYear(), d.getMonth(), 1);
   });
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOverDate, setDragOverDate] = useState<string | null>(null);
 
   const nameMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -51,7 +54,12 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
   const cells: ReactElement[] = [];
   for (let i = 0; i < startOffset; i++) {
     cells.push(
-      <div key={`pre-${i}`} role="gridcell" className="h-24 border bg-gray-50" aria-hidden="true" />,
+      <div
+        key={`pre-${i}`}
+        role="gridcell"
+        className="h-24 border bg-gray-50"
+        aria-hidden="true"
+      />,
     );
   }
 
@@ -63,14 +71,37 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
         key={dateStr}
         role="gridcell"
         aria-label={dateStr}
-        className="h-24 border p-1 overflow-y-auto bg-white"
+        className={`h-24 border p-1 overflow-y-auto bg-white ${
+          dragOverDate === dateStr ? 'ring-2 ring-blue-300' : ''
+        }`}
+        onDragOver={(e) => {
+          if (draggingId) e.preventDefault();
+        }}
+        onDragEnter={() => draggingId && setDragOverDate(dateStr)}
+        onDragLeave={() => dragOverDate === dateStr && setDragOverDate(null)}
+        onDrop={(e) => {
+          e.preventDefault();
+          const id = e.dataTransfer.getData('text/plain');
+          if (id) onMoveTask?.(id, dateStr);
+          setDragOverDate(null);
+          setDraggingId(null);
+        }}
       >
         <div className="text-xs">{day}</div>
         {ts.map((t) => (
           <div
             key={t.id}
             data-testid="task-block"
-            className={`mt-1 rounded p-1 text-xs ${t.completed ? 'bg-green-100 opacity-50' : 'bg-blue-100'}`}
+            draggable={!t.completed}
+            onDragStart={(e) => {
+              if (t.completed) return;
+              e.dataTransfer.setData('text/plain', t.id);
+              setDraggingId(t.id);
+            }}
+            onDragEnd={() => setDraggingId(null)}
+            className={`mt-1 rounded p-1 text-xs ${
+              t.completed ? 'bg-green-100 opacity-50' : 'bg-blue-100'
+            } ${draggingId === t.id ? 'rotate-2 ring-2 ring-blue-300' : ''}`}
           >
             <label className="flex items-center gap-1">
               <input
@@ -93,24 +124,47 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
   const endOffset = (7 - (totalCells % 7)) % 7;
   for (let i = 0; i < endOffset; i++) {
     cells.push(
-      <div key={`post-${i}`} role="gridcell" className="h-24 border bg-gray-50" aria-hidden="true" />,
+      <div
+        key={`post-${i}`}
+        role="gridcell"
+        className="h-24 border bg-gray-50"
+        aria-hidden="true"
+      />,
     );
   }
 
   return (
-    <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="カレンダービュー">
+    <section
+      className="rounded-lg border bg-white p-6 shadow-sm mt-8"
+      aria-label="カレンダービュー"
+    >
       <div className="mb-4 flex items-center justify-between">
         <div className="font-semibold">
           {year}年{month + 1}月
         </div>
         <div className="space-x-2">
-          <button type="button" onClick={prevMonth} aria-label="前の月" className="px-2 py-1 border rounded">
+          <button
+            type="button"
+            onClick={prevMonth}
+            aria-label="前の月"
+            className="px-2 py-1 border rounded"
+          >
             前
           </button>
-          <button type="button" onClick={goToday} aria-label="今日" className="px-2 py-1 border rounded">
+          <button
+            type="button"
+            onClick={goToday}
+            aria-label="今日"
+            className="px-2 py-1 border rounded"
+          >
             今日
           </button>
-          <button type="button" onClick={nextMonth} aria-label="次の月" className="px-2 py-1 border rounded">
+          <button
+            type="button"
+            onClick={nextMonth}
+            aria-label="次の月"
+            className="px-2 py-1 border rounded"
+          >
             次
           </button>
         </div>

--- a/src/pages/PlannerPage.test.tsx
+++ b/src/pages/PlannerPage.test.tsx
@@ -53,5 +53,45 @@ describe('PlannerPage', () => {
     fireEvent.click(within(block).getByRole('checkbox'));
     expect(await screen.findByText('進捗率: 100%')).toBeInTheDocument();
   });
+
+  it('moves task to another date', async () => {
+    localStorage.setItem(
+      'goal-steps:project-settings',
+      JSON.stringify({ name: 'P', deadline: '2025-12-31' }),
+    );
+    const categories = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    localStorage.setItem('goal-steps:categories', JSON.stringify(categories));
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth();
+    const d1 = new Date(year, month, 15).toISOString().slice(0, 10);
+    const d2 = new Date(year, month, 16).toISOString().slice(0, 10);
+    const tasks = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: d1, completed: false },
+    ];
+    localStorage.setItem('goal-steps:tasks', JSON.stringify(tasks));
+    render(<PlannerPage />);
+
+    const moveBtn = await screen.findByRole('button', { name: 'タスク移動モード' });
+    fireEvent.click(moveBtn);
+    const sourceCell = screen.getByLabelText(d1);
+    const block = within(sourceCell).getByTestId('task-block');
+    fireEvent.click(block);
+    const targetCell = screen.getByLabelText(d2);
+    fireEvent.click(targetCell);
+
+    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+    expect(within(sourceCell).queryByText('カテゴリ1: 1')).toBeNull();
+  });
 });
 

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -66,6 +66,12 @@ const PlannerPage: FC = () => {
     localStorage.setItem(TASK_KEY, JSON.stringify(next));
   };
 
+  const handleMoveTask = (id: string, date: string) => {
+    const next = tasks.map((t) => (t.id === id ? { ...t, date } : t));
+    setTasks(next);
+    localStorage.setItem(TASK_KEY, JSON.stringify(next));
+  };
+
   const completed = tasks.filter((t) => t.completed).length;
   const progress = tasks.length ? Math.round((completed / tasks.length) * 100) : 0;
 
@@ -89,7 +95,12 @@ const PlannerPage: FC = () => {
             <p>進捗率: {progress}%</p>
           </section>
         )}
-        <CalendarView tasks={tasks} categories={categories} onToggleTask={handleToggleTask} />
+        <CalendarView
+          tasks={tasks}
+          categories={categories}
+          onToggleTask={handleToggleTask}
+          onMoveTask={handleMoveTask}
+        />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow manual task relocation via drag and drop in calendar view
- highlight task blocks and cells during drag operations
- test drag restrictions and movement behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c361b01670832d8d089e93322ccd71