### PR TITLE
style: soften UI colors and remove borders

### DIFF
--- a/src/components/AutoPlanButton.tsx
+++ b/src/components/AutoPlanButton.tsx
@@ -13,12 +13,12 @@ const AutoPlanButton: FC<Props> = ({ onPlan }) => {
   };
 
   return (
-    <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="自動計画">
+    <section className="rounded-lg bg-white p-6 shadow-sm mt-8" aria-label="自動計画">
       <h2 className="text-lg font-semibold mb-4">自動計画</h2>
       <button
         type="button"
         onClick={handleClick}
-        className="rounded bg-green-600 px-3 py-1.5 text-white hover:bg-green-700"
+        className="rounded bg-green-500 px-3 py-1.5 text-white hover:bg-green-600"
       >
         自動計画を作成
       </button>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -51,7 +51,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
   const cells: ReactElement[] = [];
   for (let i = 0; i < startOffset; i++) {
     cells.push(
-      <div key={`pre-${i}`} role="gridcell" className="h-24 border bg-gray-50" aria-hidden="true" />,
+      <div key={`pre-${i}`} role="gridcell" className="h-24 bg-gray-50" aria-hidden="true" />,
     );
   }
 
@@ -63,7 +63,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
         key={dateStr}
         role="gridcell"
         aria-label={dateStr}
-        className="h-24 border p-1 overflow-y-auto bg-white"
+        className="h-24 p-1 overflow-y-auto bg-white"
       >
         <div className="text-xs">{day}</div>
         {ts.map((t) => (
@@ -93,24 +93,24 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
   const endOffset = (7 - (totalCells % 7)) % 7;
   for (let i = 0; i < endOffset; i++) {
     cells.push(
-      <div key={`post-${i}`} role="gridcell" className="h-24 border bg-gray-50" aria-hidden="true" />,
+      <div key={`post-${i}`} role="gridcell" className="h-24 bg-gray-50" aria-hidden="true" />,
     );
   }
 
   return (
-    <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="カレンダービュー">
+    <section className="rounded-lg bg-white p-6 shadow-sm mt-8" aria-label="カレンダービュー">
       <div className="mb-4 flex items-center justify-between">
         <div className="font-semibold">
           {year}年{month + 1}月
         </div>
         <div className="space-x-2">
-          <button type="button" onClick={prevMonth} aria-label="前の月" className="px-2 py-1 border rounded">
+          <button type="button" onClick={prevMonth} aria-label="前の月" className="rounded bg-gray-100 px-2 py-1 hover:bg-gray-200">
             前
           </button>
-          <button type="button" onClick={goToday} aria-label="今日" className="px-2 py-1 border rounded">
+          <button type="button" onClick={goToday} aria-label="今日" className="rounded bg-gray-100 px-2 py-1 hover:bg-gray-200">
             今日
           </button>
-          <button type="button" onClick={nextMonth} aria-label="次の月" className="px-2 py-1 border rounded">
+          <button type="button" onClick={nextMonth} aria-label="次の月" className="rounded bg-gray-100 px-2 py-1 hover:bg-gray-200">
             次
           </button>
         </div>
@@ -122,7 +122,7 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask 
           </div>
         ))}
       </div>
-      <div role="grid" className="grid grid-cols-7 gap-px bg-gray-300">
+      <div role="grid" className="grid grid-cols-7 gap-px bg-gray-200">
         {cells}
       </div>
     </section>

--- a/src/components/CategoryManager.tsx
+++ b/src/components/CategoryManager.tsx
@@ -120,7 +120,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
   };
 
   return (
-    <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="カテゴリー管理">
+    <section className="rounded-lg bg-white p-6 shadow-sm mt-8" aria-label="カテゴリー管理">
       <h2 className="text-lg font-semibold mb-4">{editingId ? 'カテゴリーの編集' : 'カテゴリーの追加'}</h2>
       <form onSubmit={handleSubmit} className="grid gap-4 md:grid-cols-2" aria-label="カテゴリー作成フォーム">
         <div>
@@ -128,7 +128,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
           <input
             id="cat-name"
             type="text"
-            className={`mt-1 w-full rounded border px-3 py-2 ${((touched.name || submitted) && errors.name) ? 'border-red-500' : ''}`}
+            className={`mt-1 w-full rounded border border-gray-300 px-3 py-2 ${((touched.name || submitted) && errors.name) ? 'border-red-500' : ''}`}
             value={name}
             onChange={(e) => setName(e.target.value)}
             onBlur={() => markTouched('name')}
@@ -148,7 +148,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
               type="number"
               min={1}
               step={1}
-              className={`mt-1 w-full rounded border px-3 py-2 ${((touched.min || submitted) && errors.minAmount) ? 'border-red-500' : ''}`}
+              className={`mt-1 w-full rounded border border-gray-300 px-3 py-2 ${((touched.min || submitted) && errors.minAmount) ? 'border-red-500' : ''}`}
               value={minAmount}
               onChange={(e) => setMinAmount(e.target.value === '' ? '' : Number(e.target.value))}
               onBlur={() => markTouched('min')}
@@ -167,7 +167,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
               type="number"
               min={1}
               step={1}
-              className={`mt-1 w-full rounded border px-3 py-2 ${((touched.max || submitted) && errors.maxAmount) ? 'border-red-500' : ''}`}
+              className={`mt-1 w-full rounded border border-gray-300 px-3 py-2 ${((touched.max || submitted) && errors.maxAmount) ? 'border-red-500' : ''}`}
               value={maxAmount}
               onChange={(e) => setMaxAmount(e.target.value === '' ? '' : Number(e.target.value))}
               onBlur={() => markTouched('max')}
@@ -187,7 +187,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
             type="number"
             min={1}
             step={1}
-            className={`mt-1 w-full rounded border px-3 py-2 ${((touched.unit || submitted) && errors.minUnit) ? 'border-red-500' : ''}`}
+            className={`mt-1 w-full rounded border border-gray-300 px-3 py-2 ${((touched.unit || submitted) && errors.minUnit) ? 'border-red-500' : ''}`}
             value={minUnit}
             onChange={(e) => setMinUnit(e.target.value === '' ? '' : Number(e.target.value))}
             onBlur={() => markTouched('unit')}
@@ -204,7 +204,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
           <input
             id="cat-deadline"
             type="date"
-            className={`mt-1 w-full rounded border px-3 py-2 ${((touched.deadline || submitted) && errors.deadline) ? 'border-red-500' : ''}`}
+            className={`mt-1 w-full rounded border border-gray-300 px-3 py-2 ${((touched.deadline || submitted) && errors.deadline) ? 'border-red-500' : ''}`}
             value={deadline}
             onChange={(e) => setDeadline(e.target.value)}
             onBlur={() => markTouched('deadline')}
@@ -219,7 +219,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
         <div className="md:col-span-2 flex gap-2">
           <button
             type="submit"
-            className="rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700 disabled:opacity-50"
+            className="rounded bg-blue-500 px-3 py-1.5 text-white hover:bg-blue-600 disabled:opacity-50"
             disabled={!valid}
           >
             {editingId ? '更新' : '追加'}
@@ -227,7 +227,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
           {editingId && (
             <button
               type="button"
-              className="rounded border px-3 py-1.5"
+              className="rounded bg-gray-100 px-3 py-1.5 hover:bg-gray-200"
               onClick={resetForm}
             >
               キャンセル
@@ -241,7 +241,7 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
         {categories.length === 0 ? (
           <p className="text-sm text-gray-600">まだカテゴリーがありません</p>
         ) : (
-          <ul className="divide-y rounded border">
+          <ul className="divide-y divide-gray-200 rounded bg-gray-50">
             {categories.map((c) => (
               <li key={c.id} className="p-3 flex items-center justify-between">
                 <div>
@@ -254,14 +254,14 @@ const CategoryManager: FC<Props> = ({ categories, onAdd, onUpdate, onDelete }) =
                 <div className="flex gap-2">
                   <button
                     type="button"
-                    className="rounded border px-2 py-1 text-sm"
+                    className="rounded bg-gray-100 px-2 py-1 text-sm hover:bg-gray-200"
                     onClick={() => startEdit(c)}
                   >
                     編集
                   </button>
                   <button
                     type="button"
-                    className="rounded border px-2 py-1 text-sm text-red-600"
+                    className="rounded bg-red-50 px-2 py-1 text-sm text-red-700 hover:bg-red-100"
                     onClick={() => onDelete(c.id)}
                   >
                     削除

--- a/src/components/ProjectSettingsForm.tsx
+++ b/src/components/ProjectSettingsForm.tsx
@@ -34,7 +34,7 @@ const ProjectSettingsForm: FC = () => {
   };
 
   return (
-    <section className="rounded-lg border bg-white p-6 shadow-sm">
+    <section className="rounded-lg bg-white p-6 shadow-sm">
       <h2 className="text-lg font-semibold mb-4">プロジェクトの設定</h2>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
@@ -44,7 +44,7 @@ const ProjectSettingsForm: FC = () => {
           <input
             id="project-name"
             type="text"
-            className="mt-1 w-full rounded border px-3 py-2"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
@@ -57,7 +57,7 @@ const ProjectSettingsForm: FC = () => {
           <input
             id="project-deadline"
             type="date"
-            className="mt-1 w-full rounded border px-3 py-2"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
             value={deadline}
             onChange={(e) => setDeadline(e.target.value)}
             required
@@ -65,7 +65,7 @@ const ProjectSettingsForm: FC = () => {
         </div>
         <button
           type="submit"
-          className="rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700"
+          className="rounded bg-blue-500 px-3 py-1.5 text-white hover:bg-blue-600"
         >
           保存
         </button>

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -70,7 +70,7 @@ const PlannerPage: FC = () => {
   const progress = tasks.length ? Math.round((completed / tasks.length) * 100) : 0;
 
   return (
-    <div className="min-h-screen p-6 md:p-10">
+    <div className="min-h-screen bg-gray-50 p-6 md:p-10">
       <header className="mx-auto max-w-5xl">
         <h1 className="text-2xl md:text-3xl font-bold">goal-steps</h1>
         <p className="text-sm text-gray-600 mt-1">目標達成のためのタスク管理を補助するアプリ</p>
@@ -85,7 +85,7 @@ const PlannerPage: FC = () => {
         />
         <AutoPlanButton onPlan={handlePlan} />
         {tasks.length > 0 && (
-          <section className="rounded-lg border bg-white p-6 shadow-sm mt-8" aria-label="進捗">
+          <section className="rounded-lg bg-white p-6 shadow-sm mt-8" aria-label="進捗">
             <p>進捗率: {progress}%</p>
           </section>
         )}


### PR DESCRIPTION
## Summary
- remove sharp borders and switch to softer backgrounds across planner UI
- update buttons and inputs with gentle color palette
- adjust calendar grid and controls to match new style

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c3cbdec8832da2acdb8cf177c195