### PR TITLE
feat: show daily progress

### DIFF
--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -98,6 +98,32 @@ describe('CalendarView', () => {
     expect(within(cell).getByText('カテゴリ2: 4')).toBeInTheDocument();
   });
 
+  it('displays daily progress bar with completed and total counts', () => {
+    const categories: Category[] = [
+      {
+        id: 'c1',
+        name: 'カテゴリ1',
+        minAmount: 1,
+        maxAmount: 1,
+        minUnit: 1,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+    const tasks: TaskBlock[] = [
+      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-10', completed: false },
+      { id: 't2', categoryId: 'c1', amount: 1, date: '2025-01-10', completed: true },
+    ];
+    render(
+      <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
+    );
+    const cell = screen.getByLabelText('2025-01-10');
+    const bar = within(cell).getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '1');
+    expect(bar).toHaveAttribute('aria-valuemax', '2');
+    expect(within(cell).getByText('1/2')).toBeInTheDocument();
+  });
+
   it('toggles task completion', () => {
     const categories: Category[] = [
       {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -132,6 +132,9 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
   for (let day = 1; day <= days; day++) {
     const dateStr = formatDate(year, month, day);
     const ts = grouped[dateStr] || [];
+    const total = ts.length;
+    const completedCount = ts.filter((t) => t.completed).length;
+    const percent = total ? Math.round((completedCount / total) * 100) : 0;
     cells.push(
       <div
         key={dateStr}
@@ -168,6 +171,23 @@ const CalendarView: FC<Props> = ({ tasks, categories, initialDate, onToggleTask,
         }}
       >
         <div className="text-xs">{day}</div>
+        <div className="mt-1">
+          <div
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuenow={completedCount}
+            aria-valuemax={total}
+            className="h-1 w-full rounded bg-gray-200"
+          >
+            <div
+              className="h-1 rounded bg-green-400"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <div className="mt-1 text-[10px] text-right">
+            {completedCount}/{total}
+          </div>
+        </div>
         {ts.map((t) => (
           <div
             key={t.id}


### PR DESCRIPTION
## Summary
- display per-day task completion progress bars on calendar
- add tests for daily progress display

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c4cc84da00832d8c12b79bda4d9e2c