### PR TITLE
タスクブロックに開始と終了を表示

### DIFF
--- a/src/components/CalendarCell.test.tsx
+++ b/src/components/CalendarCell.test.tsx
@@ -9,7 +9,7 @@ describe('CalendarCell', () => {
   it('renders day and tasks', () => {
     const nameMap = new Map<string, string>([['c1', 'カテゴリ1']]);
     const tasks: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-01', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-01', completed: false },
     ];
     const draggingRef: MutableRefObject<string | null> = { current: null };
     const selectedRef: MutableRefObject<string | null> = { current: null };
@@ -32,7 +32,7 @@ describe('CalendarCell', () => {
       />
     );
     expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('カテゴリ1: 1')).toBeInTheDocument();
+    expect(screen.getByText('カテゴリ1: 1-1')).toBeInTheDocument();
   });
 
   it('applies gray style for other month', () => {

--- a/src/components/CalendarCell.tsx
+++ b/src/components/CalendarCell.tsx
@@ -140,7 +140,7 @@ const CalendarCell: FC<Props> = ({
               aria-label="完了"
             />
             <span className={t.completed ? 'line-through' : undefined}>
-              {nameMap.get(t.categoryId) ?? t.categoryId}: {t.amount}
+              {nameMap.get(t.categoryId) ?? t.categoryId}: {t.start}-{t.end}
             </span>
           </label>
         </div>

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -55,9 +55,9 @@ describe('CalendarView', () => {
       },
     ];
     const tasks: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
-      { id: 't2', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
-      { id: 't3', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: false },
+      { id: 't2', categoryId: 'c1', amount: 1, start: 2, end: 2, date: '2025-01-05', completed: false },
+      { id: 't3', categoryId: 'c1', amount: 1, start: 3, end: 3, date: '2025-01-05', completed: false },
     ];
     render(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
@@ -82,13 +82,13 @@ describe('CalendarView', () => {
       },
     ];
     const tasks: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 2, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 2, start: 1, end: 2, date: '2025-01-05', completed: false },
     ];
     render(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
     const cell = screen.getByLabelText('2025-01-05');
-    expect(within(cell).getByText('カテゴリ1: 2')).toBeInTheDocument();
+    expect(within(cell).getByText('カテゴリ1: 1-2')).toBeInTheDocument();
   });
 
   it('updates when tasks prop changes', () => {
@@ -107,18 +107,18 @@ describe('CalendarView', () => {
     const { rerender } = render(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
-    tasks.push({ id: 't2', categoryId: 'c1', amount: 3, date: '2025-01-10', completed: false });
+    tasks.push({ id: 't2', categoryId: 'c1', amount: 3, start: 1, end: 3, date: '2025-01-10', completed: false });
     rerender(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
     );
     const cell = screen.getByLabelText('2025-01-10');
-    expect(within(cell).getByText('カテゴリ1: 3')).toBeInTheDocument();
+    expect(within(cell).getByText('カテゴリ1: 1-3')).toBeInTheDocument();
   });
 
   it('shows category names when categories prop updates', () => {
     const categories: Category[] = [];
     const tasks: TaskBlock[] = [
-      { id: 't3', categoryId: 'c2', amount: 4, date: '2025-01-15', completed: false },
+      { id: 't3', categoryId: 'c2', amount: 4, start: 1, end: 4, date: '2025-01-15', completed: false },
     ];
     const { rerender } = render(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
@@ -140,7 +140,7 @@ describe('CalendarView', () => {
       />,
     );
     const cell = screen.getByLabelText('2025-01-15');
-    expect(within(cell).getByText('カテゴリ2: 4')).toBeInTheDocument();
+    expect(within(cell).getByText('カテゴリ2: 1-4')).toBeInTheDocument();
   });
 
   it('displays daily progress bar with completed and total counts', () => {
@@ -156,8 +156,8 @@ describe('CalendarView', () => {
       },
     ];
     const tasks: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-10', completed: false },
-      { id: 't2', categoryId: 'c1', amount: 1, date: '2025-01-10', completed: true },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-10', completed: false },
+      { id: 't2', categoryId: 'c1', amount: 1, start: 2, end: 2, date: '2025-01-10', completed: true },
     ];
     render(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
@@ -182,7 +182,7 @@ describe('CalendarView', () => {
       },
     ];
     const initial: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: false },
     ];
 
     const Wrapper: FC = () => {
@@ -220,7 +220,7 @@ describe('CalendarView', () => {
       },
     ];
     const tasks: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: false },
     ];
     const toggle = vi.fn();
     render(
@@ -235,7 +235,7 @@ describe('CalendarView', () => {
     fireEvent.click(moveBtn);
     const cell = screen.getByLabelText('2025-01-05');
     const block = within(cell).getByTestId('task-block');
-    fireEvent.click(within(block).getByText('カテゴリ1: 1'));
+    fireEvent.click(within(block).getByText('カテゴリ1: 1-1'));
     expect(toggle).not.toHaveBeenCalled();
     expect(block).not.toHaveClass('opacity-50');
   });
@@ -253,7 +253,7 @@ describe('CalendarView', () => {
       },
     ];
     const tasks: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: true },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: true },
     ];
     render(
       <CalendarView tasks={tasks} categories={categories} initialDate={new Date('2025-01-01')} />,
@@ -275,7 +275,7 @@ describe('CalendarView', () => {
       },
     ];
     const initial: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: false },
     ];
 
     const Wrapper: FC = () => {
@@ -316,7 +316,7 @@ describe('CalendarView', () => {
     fireEvent.dragOver(targetCell, { dataTransfer: data });
     fireEvent.drop(targetCell, { dataTransfer: data });
 
-    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+    expect(within(targetCell).getByText('カテゴリ1: 1-1')).toBeInTheDocument();
   });
 
   it('moves task via touch interaction', () => {
@@ -332,7 +332,7 @@ describe('CalendarView', () => {
       },
     ];
     const initial: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: false },
     ];
 
     const Wrapper: FC = () => {
@@ -361,7 +361,7 @@ describe('CalendarView', () => {
     fireEvent.touchEnd(document, { changedTouches: [{ clientX: 10, clientY: 10 }] });
 
     doc.elementFromPoint = original;
-    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+    expect(within(targetCell).getByText('カテゴリ1: 1-1')).toBeInTheDocument();
   });
 
   it('moves task via move mode selection', () => {
@@ -377,7 +377,7 @@ describe('CalendarView', () => {
       },
     ];
     const initial: TaskBlock[] = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: '2025-01-05', completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: '2025-01-05', completed: false },
     ];
 
     const Wrapper: FC = () => {
@@ -404,6 +404,6 @@ describe('CalendarView', () => {
     const targetCell = screen.getByLabelText('2025-01-06');
     fireEvent.click(targetCell);
 
-    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
+    expect(within(targetCell).getByText('カテゴリ1: 1-1')).toBeInTheDocument();
   });
 });

--- a/src/lib/autoAllocate.ts
+++ b/src/lib/autoAllocate.ts
@@ -100,13 +100,17 @@ export function autoAllocateTasks(today = new Date()): TaskBlock[] {
     if (weightedDays.length === 0) continue;
     const unit = c.minUnit;
     let remaining = c.maxAmount;
+    let current = 1;
     let i = 0;
     let attempts = 0;
     while (remaining > 0) {
       const date = weightedDays[i % weightedDays.length];
       const amount = remaining >= unit ? unit : remaining;
       if (capacities[date] >= amount || capacities[date] > 0) {
-        tasks.push({ id: uid(), categoryId: c.id, amount, date, completed: false });
+        const start = current;
+        const end = start + amount - 1;
+        tasks.push({ id: uid(), categoryId: c.id, amount, start, end, date, completed: false });
+        current += amount;
         capacities[date] -= amount;
         if (capacities[date] < 0) capacities[date] = 0;
         remaining -= amount;

--- a/src/pages/PlannerPage.test.tsx
+++ b/src/pages/PlannerPage.test.tsx
@@ -44,7 +44,7 @@ describe('PlannerPage', () => {
     localStorage.setItem('goal-steps:categories', JSON.stringify(categories));
     const today = new Date().toISOString().slice(0, 10);
     const tasks = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: today, completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: today, completed: false },
     ];
     localStorage.setItem('goal-steps:tasks', JSON.stringify(tasks));
     render(<PlannerPage />);
@@ -77,7 +77,7 @@ describe('PlannerPage', () => {
     const d1 = new Date(year, month, 15).toISOString().slice(0, 10);
     const d2 = new Date(year, month, 16).toISOString().slice(0, 10);
     const tasks = [
-      { id: 't1', categoryId: 'c1', amount: 1, date: d1, completed: false },
+      { id: 't1', categoryId: 'c1', amount: 1, start: 1, end: 1, date: d1, completed: false },
     ];
     localStorage.setItem('goal-steps:tasks', JSON.stringify(tasks));
     render(<PlannerPage />);
@@ -90,8 +90,8 @@ describe('PlannerPage', () => {
     const targetCell = screen.getByLabelText(d2);
     fireEvent.click(targetCell);
 
-    expect(within(targetCell).getByText('カテゴリ1: 1')).toBeInTheDocument();
-    expect(within(sourceCell).queryByText('カテゴリ1: 1')).toBeNull();
+    expect(within(targetCell).getByText('カテゴリ1: 1-1')).toBeInTheDocument();
+    expect(within(sourceCell).queryByText('カテゴリ1: 1-1')).toBeNull();
   });
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,8 @@ export interface TaskBlock {
   id: ID;
   categoryId: ID;
   amount: number;
+  start: number;
+  end: number;
   date: string; // YYYY-MM-DD
   completed: boolean;
 }


### PR DESCRIPTION
## 概要
- タスクブロックを開始-終了形式で表示
- 自動割り当てで開始・終了範囲を記録
- 関連テストの更新

## テスト
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d66e5620832d9edfb3b59dddc8d2